### PR TITLE
Add app build event stream to front end

### DIFF
--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -4,7 +4,6 @@ const App = require('../server/models').App;
 const slugify = require('slugify');
 const uuidv1 = require('uuid/v1');
 const fs = require('fs');
-const eventLogger = require('../lib/EventLogger');
 
 module.exports = {
   create(req, res) {
@@ -28,14 +27,16 @@ module.exports = {
       App.create(app)
         .then((app) => {
           res.redirect(`apps/${app.id}?events`);
-          eventLogger.emit(`message-${app.id}`, `Creating application '${app.title}'`);
+          app.emitEvent(`Creating application '${app.title}'`)
           return app;
         })
         .then(DockerWrapper.buildDockerfile(req.file.filename + '.zip'))
         .then(DockerWrapper.buildImage)
         .then(DockerWrapper.createNetwork)
         .then(DockerWrapper.createService)
-        .then((app) => eventLogger.emit(`message-${app.id}`, '===END==='))
+        .then((app) => {
+          app.emitEvent('===END===');
+        })
         .catch(error => { throw error; });
     });
   },

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -6,7 +6,6 @@ const path = require('path');
 const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
-const eventLogger = require('../lib/EventLogger');
 
 const webDockerfileContent = (filename) => {
   return `FROM ruby:2.6
@@ -54,12 +53,11 @@ module.exports = {
   buildDockerfile: (filename) => {
     return (app) => {
       return new Promise((resolve, reject) => {
-
-        eventLogger.emit(`message-${app.id}`, 'Building Dockerfile...');
-        console.log('Building Dockerfile...')
+        console.log(app);
+        app.emitEvent('Building Dockerfile...');
         fs.writeFile(`./${app.path}/Dockerfile`, webDockerfileContent(filename), (err) => {
           if (err) { reject(err); }
-          console.log('Built Dockerfile!');
+          app.emitEvent('Built Dockerfile!');
           resolve(app);
         });
       });
@@ -71,8 +69,7 @@ module.exports = {
       const managerNode = await getManagerNodeInstance();
       const tarStream = tar.pack(app.path);
 
-      eventLogger.emit(`message-${app.id}`, 'Building image...');
-      console.log('Building image...');
+      app.emitEvent('Building image...');
       managerNode.buildImage(tarStream, {
         t: `${app.title}:latest`,
       }, function(error, output) {
@@ -81,14 +78,10 @@ module.exports = {
         }
 
         output.pipe(process.stdout);
-        output.on('data', (data) => {
-          const message = JSON.parse(data);
-          eventLogger.emit(`message-${app.id}`, message.stream);
-        });
+        output.on('data', data => app.emitStdout(data));
         output.on('end', function () {
           // send notification to client that build is ready
-          eventLogger.emit(`message-${app.id}`, 'Image built!');
-          console.log('Image built!');
+          app.emitEvent('Image built!');
           resolve(app);
         });
       });
@@ -120,12 +113,10 @@ module.exports = {
         },
       };
 
-      eventLogger.emit(`message-${app.id}`, 'Creating service...');
-      console.log('Creating service...');
+      app.emitEvent('Creating service...');
       managerNode.createService(serviceParams, (error, result) => {
         if (error) { console.log(error); }
-        eventLogger.emit(`message-${app.id}`, 'Service created!');
-        console.log('Service created!');
+        app.emitEvent('Service created!');
         resolve(app);
       });
     });
@@ -140,12 +131,10 @@ module.exports = {
         "Driver": "overlay"
       };
 
-      eventLogger.emit(`message-${app.id}`, 'Creating network...');
-      console.log('Creating network...');
+      app.emitEvent('Creating network...');
       managerNode.createNetwork(networkOptions, (error, result) => {
         if (error) { console.log(error); }
-        eventLogger.emit(`message-${app.id}`, 'Network created!');
-        console.log('Network created!');
+        app.emitEvent('Network created!');
         resolve(app);
       });
     });
@@ -174,8 +163,7 @@ module.exports = {
 
       const tarStream = tar.pack(app.path + '/db');
 
-      eventLogger.emit(`message-${app.id}`, 'Building DB image...');
-      console.log('Building db image...');
+      app.emitEvent('Building db image...');
       managerNode.buildImage(tarStream, {
         t: `${app.title}_database:latest`,
       }, function(error, output) {
@@ -186,14 +174,11 @@ module.exports = {
         output.pipe(process.stdout);
         output.on('end', function () {
           // send notification to client that build is ready
-          eventLogger.emit(`message-${app.id}`, 'DB image built!');
-          console.log('DB image built!');
-          eventLogger.emit(`message-${app.id}`, 'Creating DB service...');
-          console.log('Creating database service...');
+          app.emitEvent('DB image built!');
+          app.emitEvent('Creating database service...');
           managerNode.createService(serviceParams, (error, result) => {
             if (error) { console.log(error); }
-            eventLogger.emit(`message-${app.id}`, 'DB service created!');
-            console.log('Database service created!');
+            app.emitEvent('Database service created!');
             resolve(app);
           });
         });
@@ -236,12 +221,10 @@ module.exports = {
         const version = result.Version.Index;
         serviceParams._query = { "version": version };
 
-        eventLogger.emit(`message-${app.id}`, 'Updating web service with DB env params...');
-        console.log('Updating web service with DB env params');
+        app.emitEvent('Updating web service with DB env params');
         service.update(serviceParams, (error, result) => {
           if (error) { console.log(error); }
-          eventLogger.emit(`message-${app.id}`, 'Web service updated with DB env params!');
-          console.log('Web service updated!');
+          app.emitEvent('Web service updated!');
           resolve(app);
         });
       });

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -53,7 +53,6 @@ module.exports = {
   buildDockerfile: (filename) => {
     return (app) => {
       return new Promise((resolve, reject) => {
-        console.log(app);
         app.emitEvent('Building Dockerfile...');
         fs.writeFile(`./${app.path}/Dockerfile`, webDockerfileContent(filename), (err) => {
           if (err) { reject(err); }

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -6,6 +6,7 @@ const path = require('path');
 const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
+const eventLogger = require('../lib/EventLogger');
 
 const webDockerfileContent = (filename) => {
   return `FROM ruby:2.6
@@ -53,6 +54,8 @@ module.exports = {
   buildDockerfile: (filename) => {
     return (app) => {
       return new Promise((resolve, reject) => {
+
+        eventLogger.emit(`message-${app.id}`, 'Building Dockerfile...');
         console.log('Building Dockerfile...')
         fs.writeFile(`./${app.path}/Dockerfile`, webDockerfileContent(filename), (err) => {
           if (err) { reject(err); }
@@ -68,6 +71,7 @@ module.exports = {
       const managerNode = await getManagerNodeInstance();
       const tarStream = tar.pack(app.path);
 
+      eventLogger.emit(`message-${app.id}`, 'Building image...');
       console.log('Building image...');
       managerNode.buildImage(tarStream, {
         t: `${app.title}:latest`,
@@ -75,9 +79,15 @@ module.exports = {
         if (error) {
           return console.error(error);
         }
+
         output.pipe(process.stdout);
+        output.on('data', (data) => {
+          const message = JSON.parse(data);
+          eventLogger.emit(`message-${app.id}`, message.stream);
+        });
         output.on('end', function () {
           // send notification to client that build is ready
+          eventLogger.emit(`message-${app.id}`, 'Image built!');
           console.log('Image built!');
           resolve(app);
         });
@@ -110,9 +120,11 @@ module.exports = {
         },
       };
 
+      eventLogger.emit(`message-${app.id}`, 'Creating service...');
       console.log('Creating service...');
       managerNode.createService(serviceParams, (error, result) => {
         if (error) { console.log(error); }
+        eventLogger.emit(`message-${app.id}`, 'Service created!');
         console.log('Service created!');
         resolve(app);
       });
@@ -128,10 +140,12 @@ module.exports = {
         "Driver": "overlay"
       };
 
+      eventLogger.emit(`message-${app.id}`, 'Creating network...');
       console.log('Creating network...');
       managerNode.createNetwork(networkOptions, (error, result) => {
         if (error) { console.log(error); }
-         console.log('Network created!');
+        eventLogger.emit(`message-${app.id}`, 'Network created!');
+        console.log('Network created!');
         resolve(app);
       });
     });
@@ -160,6 +174,7 @@ module.exports = {
 
       const tarStream = tar.pack(app.path + '/db');
 
+      eventLogger.emit(`message-${app.id}`, 'Building DB image...');
       console.log('Building db image...');
       managerNode.buildImage(tarStream, {
         t: `${app.title}_database:latest`,
@@ -171,10 +186,13 @@ module.exports = {
         output.pipe(process.stdout);
         output.on('end', function () {
           // send notification to client that build is ready
+          eventLogger.emit(`message-${app.id}`, 'DB image built!');
           console.log('DB image built!');
+          eventLogger.emit(`message-${app.id}`, 'Creating DB service...');
           console.log('Creating database service...');
           managerNode.createService(serviceParams, (error, result) => {
             if (error) { console.log(error); }
+            eventLogger.emit(`message-${app.id}`, 'DB service created!');
             console.log('Database service created!');
             resolve(app);
           });
@@ -218,9 +236,11 @@ module.exports = {
         const version = result.Version.Index;
         serviceParams._query = { "version": version };
 
-        console.log('Updating web service with database env params');
+        eventLogger.emit(`message-${app.id}`, 'Updating web service with DB env params...');
+        console.log('Updating web service with DB env params');
         service.update(serviceParams, (error, result) => {
           if (error) { console.log(error); }
+          eventLogger.emit(`message-${app.id}`, 'Web service updated with DB env params!');
           console.log('Web service updated!');
           resolve(app);
         });

--- a/lib/EventLogger.js
+++ b/lib/EventLogger.js
@@ -1,4 +1,33 @@
 const EventEmitter = require('events').EventEmitter;
 const eventLogger = new EventEmitter();
 
-module.exports = eventLogger;
+module.exports = {
+  eventLogger: eventLogger,
+
+  appEvents: (req, res) => {
+    const appId = req.params.appId;
+
+    res.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive'
+    });
+
+    const messageWriter = message => {
+      if (message.trim() === '===END===') {
+        console.log('Deregistering listener...');
+        eventLogger.off(`message-${appId}`, messageWriter);
+        res.write(`id: -1\n`);
+        res.write(`data:\n\n`);
+        return res.status(200).end();
+      }
+
+      const data = JSON.stringify(message);
+      res.write(`event: message\n`);
+      res.write(`data: ${data}\n\n`);
+    };
+
+    console.log(`Creating listener for 'message-${appId}'`);
+    eventLogger.on(`message-${appId}`, messageWriter);
+  },
+};

--- a/lib/EventLogger.js
+++ b/lib/EventLogger.js
@@ -1,0 +1,4 @@
+const EventEmitter = require('events').EventEmitter;
+const eventLogger = new EventEmitter();
+
+module.exports = eventLogger;

--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -25,3 +25,11 @@ nav ul li
 
 .message
   margin: 16px 0;
+
+.terminal
+  background: #222
+  font-family: 'Fira Code', Menlo, monospace
+  color: #fff
+  height: 15rem
+  overflow: auto
+  font-size: 16px

--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -33,3 +33,9 @@ nav ul li
   height: 15rem
   overflow: auto
   font-size: 16px
+
+details summary
+  font-weight: bold
+
+details[open] summary
+  margin-bottom: 1rem

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const appsController = require('../controllers/apps');
 const multer  = require('multer');
 const fs = require('fs');
 const uuid = require('uuid/v1');
+const eventLogger = require('../lib/EventLogger');
 
 const storage = multer.diskStorage({
   // TODO: validate that the file is a zip
@@ -21,6 +22,30 @@ const upload = multer({storage});
 /* GET home page. */
 router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
+});
+
+router.get('/events/:appId', (req, res) => {
+  const appId = req.params.appId;
+
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive'
+  });
+
+  const messageWriter = data => {
+    res.write(`event: message\n`);
+    res.write(`data: ${data}\n\n`);
+
+    if (data === '===END===') {
+      console.log('Deregistering listener...');
+      eventLogger.off(`message-${appId}`, messageWriter);
+      return res.status(200).end();
+    }
+  };
+
+  console.log(`Creating listener for 'message`);
+  eventLogger.on(`message-${appId}`, messageWriter);
 });
 
 // App

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,29 +24,8 @@ router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
 });
 
-router.get('/events/:appId', (req, res) => {
-  const appId = req.params.appId;
-
-  res.set({
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    'Connection': 'keep-alive'
-  });
-
-  const messageWriter = data => {
-    res.write(`event: message\n`);
-    res.write(`data: ${data}\n\n`);
-
-    if (data === '===END===') {
-      console.log('Deregistering listener...');
-      eventLogger.off(`message-${appId}`, messageWriter);
-      return res.status(200).end();
-    }
-  };
-
-  console.log(`Creating listener for 'message`);
-  eventLogger.on(`message-${appId}`, messageWriter);
-});
+// Event Streaming
+router.get('/events/:appId', eventLogger.appEvents);
 
 // App
 router.get('/apps', appsController.list);

--- a/server/models/app.js
+++ b/server/models/app.js
@@ -1,4 +1,6 @@
 'use strict';
+const eventLogger = require('../../lib/EventLogger').eventLogger;
+
 module.exports = (sequelize, DataTypes) => {
 
   const App = sequelize.define('App', {
@@ -12,6 +14,18 @@ module.exports = (sequelize, DataTypes) => {
 
   App.associate = function(models) {
     // associations can be defined here
+  };
+
+  App.prototype.emitEvent = function(message) {
+    console.log(message);
+    eventLogger.emit(`message-${this.id}`, message + '\n');
+  };
+
+  App.prototype.emitStdout = function(data) {
+    const message = JSON.parse(data);
+    if (message.stream) {
+      eventLogger.emit(`message-${this.id}`, message.stream);
+    }
   };
 
   return App;

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -1,3 +1,12 @@
+<div class="columns is-centered terminal-wrapper" style="display: none">
+  <div class="column is-three-quarters">
+    <details open="true">
+      <summary>Build Process</summary>
+      <pre class="terminal"></pre>
+    </details>
+  </div>
+</div>
+
 <div class="columns is-centered">
   <div class="column is-three-quarters">
 
@@ -35,35 +44,44 @@
   </div>
 </div>
 
-<div class="columns is-centered terminal-wrapper" style="display: none">
-  <div class="column is-three-quarters">
-    <details open="true">
-      <summary>Build Process</summary>
-      <pre class="terminal"></pre>
-    </details>
-  </div>
-</div>
-
 <script>
 (() => {
-  const terminal = document.querySelector('.terminal');
   const terminalWrapper = document.querySelector('.terminal-wrapper');
+  const terminal = document.querySelector('.terminal');
   const url = new URL(document.location.href);
   const urlParams = new URLSearchParams(url.search);
   const showTerminal = urlParams.has('events');
 
   if (showTerminal) {
-    const eventSource = new EventSource('/events/{{ app.id }}');
+    const appEventEndpoint = new EventSource('/events/{{ app.id }}');
 
-    eventSource.addEventListener('message', (event) => {
+    const minimizeTerminal = () => {
+      terminalWrapper.querySelector('details').removeAttribute('open');
+      terminalWrapper.querySelector('summary').innerHTML = 'Build Complete';
+    };
+
+    const messageHandler = (event) => {
+      if (event.lastEventId === '-1') {
+        appEventEndpoint.close();
+        minimizeTerminal();
+        return;
+      }
+
+      // This only unhides the terminal _if_ we get a message from the server.
       if (terminalWrapper.style.display !== 'flex') { terminalWrapper.style.display = 'flex'; }
 
-      terminal.innerHTML += `<p>${event.data}</p>`;
+      const message = JSON.parse(event.data);
+
+      terminal.innerHTML += message;
       terminal.scrollTop = terminal.scrollHeight;
-      if (event.data === '===END===') {
-        eventSource.close();
-      }
-    });
+    };
+
+    const errorHandler = (error) => {
+      appEventEndpoint.close();
+    };
+
+    appEventEndpoint.addEventListener('message', messageHandler);
+    appEventEndpoint.addEventListener('error', errorHandler);
   }
 })();
 </script>

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -1,5 +1,5 @@
 <div class="columns is-centered">
-  <div class="column is-half">
+  <div class="column is-three-quarters">
 
     <div class="box">
       <div class="content">
@@ -34,3 +34,36 @@
     </div>
   </div>
 </div>
+
+<div class="columns is-centered terminal-wrapper" style="display: none">
+  <div class="column is-three-quarters">
+    <details open="true">
+      <summary>Build Process</summary>
+      <pre class="terminal"></pre>
+    </details>
+  </div>
+</div>
+
+<script>
+(() => {
+  const terminal = document.querySelector('.terminal');
+  const terminalWrapper = document.querySelector('.terminal-wrapper');
+  const url = new URL(document.location.href);
+  const urlParams = new URLSearchParams(url.search);
+  const showTerminal = urlParams.has('events');
+
+  if (showTerminal) {
+    const eventSource = new EventSource('/events/{{ app.id }}');
+
+    eventSource.addEventListener('message', (event) => {
+      if (terminalWrapper.style.display !== 'flex') { terminalWrapper.style.display = 'flex'; }
+
+      terminal.innerHTML += `<p>${event.data}</p>`;
+      terminal.scrollTop = terminal.scrollHeight;
+      if (event.data === '===END===') {
+        eventSource.close();
+      }
+    });
+  }
+})();
+</script>

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -1,48 +1,61 @@
-<div class="columns is-centered terminal-wrapper" style="display: none">
+<div class="columns is-centered">
   <div class="column is-three-quarters">
-    <div class="box">
+
+    <!-- Terminal -->
+    <div class="box terminal-wrapper" style="display: none">
       <details open="true">
         <summary>Build Process</summary>
         <pre class="terminal"></pre>
       </details>
     </div>
-  </div>
-</div>
 
-<div class="columns is-centered">
-  <div class="column is-three-quarters">
-
+    <!-- App Info -->
     <div class="box">
       <div class="content">
-        <p>
-          <strong>Title:</strong>
-          {{ app.title }}
-        </p>
+        <details open="true">
+          <summary>Info</summary>
+          <div class="content">
+            <p>
+              <strong>Title:</strong>
+              {{ app.title }}
+            </p>
 
-        <p>
-          <strong>IP Address:</strong>
-          <a href="http://{{ app.ipAddress }}" target="_blank">
-            {{ app.ipAddress }}
-          </a>
+            <p>
+              <strong>IP Address:</strong>
+              <a href="http://{{ app.ipAddress }}" target="_blank">
+                {{ app.ipAddress }}
+              </a>
 
-        </p>
-
-        <p>
-          Add a database:
-          <form method="POST" action="/apps/{{ app.id }}/database" enctype="multipart/form-data">
+            </p>
             
-            <label>
-              Schema: <input type="file" name="file" />
-            </label>
-
-            <input class="button is-link" type="submit" value="Add Database" />
-          </form>
-        </p>
+            <a href='' class='button is-link'>Edit</a>
+            <a href='/apps' class='button'>Back</a>
+          </div>
+        </details>
       </div>
-
-      <a href='' class='button is-link'>Edit</a>
-      <a href='/apps' class='button'>Back</a>
     </div>
+
+    <!-- App Database -->
+    <div class="box">
+      <details open>
+        <summary>Database</summary>
+
+        <div class="content">
+          <p>
+            Add a database:
+            <form method="POST" action="/apps/{{ app.id }}/database" enctype="multipart/form-data">
+              <label>
+                Schema: <input type="file" name="file" />
+              </label>
+
+              <input class="button is-link" type="submit" value="Add Database" />
+            </form>
+          </p>
+        </div>
+      </details>
+    </div>
+
+
   </div>
 </div>
 
@@ -70,7 +83,7 @@
       }
 
       // This only unhides the terminal _if_ we get a message from the server.
-      if (terminalWrapper.style.display !== 'flex') { terminalWrapper.style.display = 'flex'; }
+      if (terminalWrapper.style.display !== 'block') { terminalWrapper.style.display = 'block'; }
 
       const message = JSON.parse(event.data);
 

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -1,9 +1,11 @@
 <div class="columns is-centered terminal-wrapper" style="display: none">
   <div class="column is-three-quarters">
-    <details open="true">
-      <summary>Build Process</summary>
-      <pre class="terminal"></pre>
-    </details>
+    <div class="box">
+      <details open="true">
+        <summary>Build Process</summary>
+        <pre class="terminal"></pre>
+      </details>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## What

* Adds feature which uses [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) to stream build log to front end during app build process
  * When user creates an app, we save the app information to the database and redirect to the app detail page, where they can follow a stream of events detailing the build process.


## How

* Adds an event stream endpoint for a given app
  * During build process, server will emit events to this endpoint describing current build action
* Add front end consumption of events endpoint
  * Subscribing to endpoint is triggered by the presence of an `events` query param on the app detail page (`?events`)
* Adds `.emitEvent` and `.emitStdout` instance methods to `App` model.
  * Calling these methods will emit an event for the given app. Any subscribers of this app's event stream will receive these messages.