### PR TITLE
run-command-bug

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -76,11 +76,12 @@ router.post('/apps/:appId/exec', (req, res) => {
       }).on('stream', stream => {
         // Clean up after there's no more output coming into our stream
         stream.on('end', () => {
-          outputStream.write('===END===');
           tail.kill();
-          outputStream.end();
-          fs.unlink(fileName, err => { if (err) { throw err } })
-        })
+          app.emitEvent('===END===');
+          outputStream.end(() => {
+            fs.unlink(fileName, err => { if (err) { throw err } })
+          });
+        });
       });
 
       res.send(200, 'OK');

--- a/routes/index.js
+++ b/routes/index.js
@@ -63,9 +63,11 @@ router.post('/apps/:appId/exec', (req, res) => {
       const outputStream = fs.createWriteStream(fileName);
       const tail = spawn("tail", ["-f", fileName]);
       tail.stdout.on('data', data => {
-        const fileContents = fs.readFileSync(fileName);
-        console.log('read from file');
-        app.emitEvent(fileContents.toString('utf8'), 'exec')
+        fs.readFile(fileName, (err, fileContents) => {
+          if (err) throw err;
+          console.log('read from file');
+          app.emitEvent(fileContents.toString('utf8'), 'exec')
+        });
       });
 
       docker.run(image, command, outputStream, (err, data, container) => {


### PR DESCRIPTION
Addresses #35 

There appeared to be a race condition between `outputStream.end` and `fs.unlink`. Additionally, I switched the method for sending the `===END===` message to be emitted directly rather than writing the message to the file.