### PR TITLE
create-app-zip-file-validation

### DIFF
--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -21,6 +21,10 @@ const moveApplicationFile = (req) => {
 
 module.exports = {
   async create(req, res) {
+    if (!req.file || req.file.mimetype !== 'application/zip') {
+      return res.render('apps/new', { errors: [{ message: 'Please attach a .zip file of your application.' }] })
+    }
+
     // TODO: Make path relative to app root directory
     const app = {
       title: req.body.title,


### PR DESCRIPTION
Addresses #10 

Handles the following cases, re-rendering the form with an error message:
- User submits the 'Create App' form without selecting a file
- User submits the 'Create App' form for a non-zip file. (Checks mimetype)