### PR TITLE
Back app databases with named volumes

### DIFF
--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -167,6 +167,13 @@ module.exports = {
               "POSTGRES_USER=postgres",
               "POSTGRES_PASSWORD=password",
               `POSTGRES_DB=${app.title}`
+            ],
+            "Mounts": [
+              {
+                "Source": `${app.title}_db_data`,
+                "Target": "/var/lib/posgresql/data",
+                "Type": "volume",
+              }
             ]
           },
           "Networks": [


### PR DESCRIPTION
DB data shouldn't live inside of ephemeral containers. This at least gets the data into the node's filesystem.

We have a column in the PaaS database's Database table for the the volume name. We need to be sure to set this when we save the app's database to the PaaS database.