### PR TITLE
Fix exec command to connect to app database

### DIFF
--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -142,7 +142,11 @@ module.exports = {
 
       const networkOptions = {
         "Name": app.network,
-        "Driver": "overlay"
+        "Driver": "overlay",
+        "Attachable": true,
+        "Options": {
+          "com.docker.network.overlay.encrypted": "true",
+        }
       };
 
       app.emitEvent('Creating network...');

--- a/routes/index.js
+++ b/routes/index.js
@@ -70,7 +70,20 @@ router.post('/apps/:appId/exec', (req, res) => {
         });
       });
 
-      docker.run(image, command, outputStream, (err, data, container) => {
+      const runOptions =  { 
+        Env: [
+          // TODO: These shouldn't be hard-coded... store in db?
+          `DATABASE_HOST=${app.title}_database`,
+          `POSTGRES_USER=postgres`,
+          `POSTGRES_PASSWORD=password`,
+          `POSTGRES_DB=${app.title}`
+        ],
+        "HostConfig": {
+          "NetworkMode": `${app.network}`,
+        },
+      };
+
+      docker.run(image, command, outputStream, runOptions, (err, data, container) => {
         // Remove one-off container once command terminates
         container.remove();
       }).on('stream', stream => {


### PR DESCRIPTION
Before, we were running exec commands inside of a one-off container, but
we weren't doing the things we needed to allow the container to connect to
the app's database (for `db:migrate` or whatever).

First, we set the appropriate environment variables, so the app knows the db
connection info. Second we join the app's network.

The second step isn't as striaghtforward as it seems: by default, standalone containers cannot connect to Swarm overlay networks, only Swarm services can. To get around this, we change the way we create networks for apps: now, we set them to be encrypted and we make them attachable.