### PR TITLE
Basic Mobile Styles

### DIFF
--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -86,3 +86,26 @@ details[open] summary
   background: #feecf0
   border-color: #f14668
   box-shadow: 0 0 0 1px #f14668
+
+@media only screen and (max-width: 600px)
+  body
+    display: block
+
+  nav.main-nav
+    display: flex
+    border-bottom: 1px solid #ddd
+
+  nav.main-nav .logo
+    padding: 16px
+    border-right: 1px solid #ddd
+
+  nav.main-nav .logo svg
+    width: 32px !important
+
+  nav.main-nav ul
+    display: flex
+    flex: 1
+    overflow-x: auto
+
+  .main-section
+    margin: 0

--- a/views/apps/index.hbs
+++ b/views/apps/index.hbs
@@ -7,33 +7,35 @@
 
       {{#if apps.length}}
         <div class="box">
-          <table class="table is-hoverable is-fullwidth">
-            <thead>
-            <tr>
-              <td>Name</td>
-              <td>URL</td>
-              <td><span class="is-pulled-right">Actions</span></td>
-            </tr>
-            </thead>
-            {{#each apps}}
+          <div class="table-container">
+            <table class="table is-hoverable is-fullwidth">
+              <thead>
               <tr>
-                <td>
-                  <a href="/apps/{{ id }}">{{title}}</a>
-                </td>
-                <td>
-                  <a href="http://{{url}}" target="_blank">
-                    http://{{url}}
-                  </a>
-                </td>
-                <td>
-                  <div class="buttons are-small is-pulled-right">
-                    <a href="/apps/edit/{{ id }}" class="button is-light">Edit</a>
-                    <a class="button is-danger is-light">Delete (NYI)</a>
-                  </div>
-                </td>
+                <td>Name</td>
+                <td>URL</td>
+                <td><span class="is-pulled-right">Actions</span></td>
               </tr>
-            {{/each}}
-          </table>
+              </thead>
+              {{#each apps}}
+                <tr>
+                  <td>
+                    <a href="/apps/{{ id }}">{{title}}</a>
+                  </td>
+                  <td>
+                    <a href="http://{{url}}" target="_blank">
+                      http://{{url}}
+                    </a>
+                  </td>
+                  <td>
+                    <div class="buttons are-small is-pulled-right">
+                      <a href="/apps/edit/{{ id }}" class="button is-light">Edit</a>
+                      <a class="button is-danger is-light">Delete (NYI)</a>
+                    </div>
+                  </td>
+                </tr>
+              {{/each}}
+            </table>
+          </div>
         </div>
       {{/if}}
 


### PR DESCRIPTION
This PR just adds some baseline mobile styles so you can at least view/navigate the PaaS on mobile.

The HTML change just wraps the main table in a `.table-container` element that Bulma provides. It enables scrolling if a table happens to horizontally overflow (pretty much only ever on mobile)