### PR TITLE
Add health check

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -34,7 +34,7 @@ wsAppHealth.on('connection', async function connection(ws, request) {
 
   const healthChecker = setInterval(async() => {
     const healthy = await DockerWrapper.appIsHealthy(appId);
-    ws.send(healthy ? 'healthy' : 'unhealthy');
+    ws.send(healthy ? 'Healthy' : 'Unhealthy');
   }, 1000);
 
   ws.on('close', () => clearInterval(healthChecker));

--- a/bin/www
+++ b/bin/www
@@ -7,9 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('paas:server');
 var http = require('http');
-var WebSocket = require('ws');
-var url = require('url');
-var DockerWrapper = require('../lib/DockerWrapper');
+var upgradeToWebSocket = require('../lib/WebSocket');
 
 /**
  * Get port from environment and store in Express.
@@ -25,36 +23,10 @@ app.set('port', port);
 var server = http.createServer(app);
 
 /**
- * Build WebSocket server
- */
-
-const wsAppHealth = new WebSocket.Server({ noServer: true });
-wsAppHealth.on('connection', async function connection(ws, request) {
-  const appId = Number(url.parse(request.url, true).query.appId);
-
-  const healthChecker = setInterval(async() => {
-    const healthy = await DockerWrapper.appIsHealthy(appId);
-    ws.send(healthy ? 'Healthy' : 'Unhealthy');
-  }, 1000);
-
-  ws.on('close', () => clearInterval(healthChecker));
-});
-
-/**
  * Handle websocket upgrades, pass to appropriate WebSocket Server
  */
 
- server.on('upgrade', function upgrade(request, socket, head) {
-  const pathname = url.parse(request.url).pathname;
-
-  if (pathname === '/app-health') {
-    wsAppHealth.handleUpgrade(request, socket, head, function done(ws) {
-      wsAppHealth.emit('connection', ws, request);
-    });
-  } else {
-    socket.destroy();
-  }
- });
+server.on('upgrade', upgradeToWebSocket);
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,9 @@
 var app = require('../app');
 var debug = require('debug')('paas:server');
 var http = require('http');
+var WebSocket = require('ws');
+var url = require('url');
+var DockerWrapper = require('../lib/DockerWrapper');
 
 /**
  * Get port from environment and store in Express.
@@ -20,6 +23,38 @@ app.set('port', port);
  */
 
 var server = http.createServer(app);
+
+/**
+ * Build WebSocket server
+ */
+
+const wsAppHealth = new WebSocket.Server({ noServer: true });
+wsAppHealth.on('connection', async function connection(ws, request) {
+  const appId = Number(url.parse(request.url, true).query.appId);
+
+  const healthChecker = setInterval(async() => {
+    const healthy = await DockerWrapper.appIsHealthy(appId);
+    ws.send(healthy ? 'healthy' : 'unhealthy');
+  }, 1000);
+
+  ws.on('close', () => clearInterval(healthChecker));
+});
+
+/**
+ * Handle websocket upgrades, pass to appropriate WebSocket Server
+ */
+
+ server.on('upgrade', function upgrade(request, socket, head) {
+  const pathname = url.parse(request.url).pathname;
+
+  if (pathname === '/app-health') {
+    wsAppHealth.handleUpgrade(request, socket, head, function done(ws) {
+      wsAppHealth.emit('connection', ws, request);
+    });
+  } else {
+    socket.destroy();
+  }
+ });
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -89,7 +89,10 @@ module.exports = {
 
         res.render('apps/show', { app });
       })
-      .catch(error => res.status(400).send(error));
+      .catch(error => {
+        console.log(error);
+        res.status(400).send(error);
+      });
   },
 
   destroy(req, res) {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -8,6 +8,7 @@ const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
 const moment = require('moment');
+const App = require('../server/models').App;
 
 
 const webDockerfileContent = (filename) => {
@@ -310,8 +311,10 @@ module.exports = {
     };
   },
 
-  appIsHealthy: async(app) => {
+  appIsHealthy: async(appId) => {
+    const app = await App.findByPk(appId);
     const docker = await getManagerNodeInstance();
+    
     const services = await docker.listServices();
     const service = services.filter(service => {
       return service.Spec.Name === app.title + '_web';

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -7,6 +7,8 @@ const path = require('path');
 const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
+const moment = require('moment');
+
 
 const webDockerfileContent = (filename) => {
   return `FROM ruby:2.6
@@ -306,5 +308,27 @@ module.exports = {
         });
       });
     };
+  },
+
+  appIsHealthy: async(app) => {
+    const docker = await getManagerNodeInstance();
+    const services = await docker.listServices();
+    const service = services.filter(service => {
+      return service.Spec.Name === app.title + '_web';
+    })[0];
+
+    const allTasks = await docker.listTasks();
+    const serviceTasks = allTasks.filter(task => task.ServiceID === service.ID);
+    const failedTasks = serviceTasks.filter(task => {
+      return task.Status.State === 'failed';
+    });
+
+    const recentlyFailed = failedTasks.filter(task => {
+      const now = moment();
+      const failTime = new moment(task.Status.Timestamp);
+      return now.diff(failTime, 'minutes') < 1;
+    });
+
+    return recentlyFailed.length < 3;
   },
 };

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -311,10 +311,16 @@ module.exports = {
     };
   },
 
-  appIsHealthy: async(appId) => {
-    const app = await App.findByPk(appId);
-    const docker = await getManagerNodeInstance();
-    
+  // This function takes an optional docker manager argument.
+  // We do this so that our websockets can obtain a manager instance
+  // on their own when they first connect to a client, that way
+  // we hit the database for the manager (and app) only once instead
+  // of every second when we call this method.
+  appIsHealthy: async(app, docker) => {
+    if (docker === undefined) {
+      docker = await getManagerNodeInstance();
+    }
+
     const services = await docker.listServices();
     const service = services.filter(service => {
       return service.Spec.Name === app.title + '_web';

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -320,9 +320,9 @@ module.exports = {
     }
 
     const services = await docker.listServices();
-    const service = services.filter(service => {
+    const service = services.find(service => {
       return service.Spec.Name === app.title + '_web';
-    })[0];
+    });
 
     const allTasks = await docker.listTasks();
     const serviceTasks = allTasks.filter(task => task.ServiceID === service.ID);

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -8,8 +8,6 @@ const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
 const moment = require('moment');
-const App = require('../server/models').App;
-
 
 const webDockerfileContent = (filename) => {
   return `FROM ruby:2.6

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -6,9 +6,11 @@ const App = require('../server/models').App;
 const wsAppHealth = new WebSocket.Server({ noServer: true });
 wsAppHealth.on('connection', async function connection(ws, request) {
   const appId = Number(url.parse(request.url, true).query.appId);
+  const app = await App.findByPk(appId);
+  const docker = await DockerWrapper.getManagerNodeInstance();
 
   const healthChecker = setInterval(async() => {
-    const healthy = await DockerWrapper.appIsHealthy(appId);
+    const healthy = await DockerWrapper.appIsHealthy(app, docker);
     ws.send(healthy ? 'Healthy' : 'Unhealthy');
   }, 1000);
 

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -1,0 +1,31 @@
+const  WebSocket = require('ws');
+const url = require('url');
+const DockerWrapper = require('../lib/DockerWrapper');
+const App = require('../server/models').App;
+
+const wsAppHealth = new WebSocket.Server({ noServer: true });
+wsAppHealth.on('connection', async function connection(ws, request) {
+  const appId = Number(url.parse(request.url, true).query.appId);
+
+  const healthChecker = setInterval(async() => {
+    const healthy = await DockerWrapper.appIsHealthy(appId);
+    ws.send(healthy ? 'Healthy' : 'Unhealthy');
+  }, 1000);
+
+  ws.on('close', () => clearInterval(healthChecker));
+});
+
+
+module.exports = function upgrade(request, socket, head) {
+  const pathname = url.parse(request.url).pathname;
+
+  switch (pathname) {
+    case '/app-health':
+    	wsAppHealth.handleUpgrade(request, socket, head, function done(ws) {
+    	  wsAppHealth.emit('connection', ws, request);
+    	});
+      break
+    default:
+	   socket.destroy();
+ }
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dockerode": "^3.0.2",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "express-ws": "^4.0.0",
     "hbs": "~4.0.4",
     "http-errors": "~1.6.3",
     "momentjs": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "~4.16.1",
     "hbs": "~4.0.4",
     "http-errors": "~1.6.3",
+    "momentjs": "^2.0.0",
     "morgan": "~1.9.1",
     "multer": "^1.4.2",
     "node-sass-middleware": "0.11.0",
@@ -26,7 +27,8 @@
     "tail": "2.0.3",
     "tail-file": "1.4.13",
     "tar-fs": "^2.0.0",
-    "uuid": "^3.3.3"
+    "uuid": "^3.3.3",
+    "ws": "^7.2.0"
   },
   "devDependencies": {
     "nodemon": "^1.19.4"

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -163,7 +163,7 @@
     document.addEventListener('DOMContentLoaded', function() {
       const output = document.getElementById('app-health');
       const websocket = new WebSocket(
-        'ws://localhost:3000/app-health?appId={{app.id}}'
+        `ws://${window.location.host}/app-health?appId={{app.id}}`
       );
 
       websocket.onopen = () => console.log('Connected to app-health');

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -29,7 +29,11 @@
           <a href="http://{{ app.url }}" target="_blank">
             {{ app.url }}
           </a>
-
+        </p>
+        
+        <p>
+          <strong>Health:</strong>
+          <span class="tag" id="app-health"></span>
         </p>
       </div>
     </details>
@@ -154,6 +158,29 @@
 </div>
 
 <script>
+  // WebSocket for updating app health
+  (() => {
+    document.addEventListener('DOMContentLoaded', function() {
+      const output = document.getElementById('app-health');
+      const websocket = new WebSocket(
+        'ws://localhost:3000/app-health?appId={{app.id}}'
+      );
+
+      websocket.onopen = () => console.log('Connected to app-health');
+      websocket.onerror = (event) => console.log(event.data);
+      websocket.onclose = () => console.log('Disconnected from app-health');
+      websocket.onmessage = (event) => {
+        if (event.data === 'Healthy') {
+          output.classList.add('is-success');
+        } else {
+          output.classList.add('is-danger');
+        }
+        output.innerHTML = event.data;
+      }
+    });
+  })();
+
+  // Handling build and exec output
   (() => {
     // Update schema file upload field to reflect name of uploaded file
     const fileInput = document.querySelector('#file-js-example input[type=file]');

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,11 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async-limiter@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -330,6 +335,25 @@ chalk@^2.0.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chokidar@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.0"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -1562,6 +1586,11 @@ moment-timezone@^0.5.21:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
 
+momentjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/momentjs/-/momentjs-2.0.0.tgz#73df904b4fa418f6e3c605e831cef6ed5518ebd4"
+  integrity sha1-c9+QS0+kGPbjxgXoMc727VUY69Q=
+
 morgan@~1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -1695,6 +1724,13 @@ node-sass@^4.3.0:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+nodejs-tail@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nodejs-tail/-/nodejs-tail-1.1.0.tgz#5e4316b079c4ec922e95ad8ac1f0a980ae7e0264"
+  integrity sha512-Gt2fi69P9tgdj41Xl9vFoLVcmnXW9uKQbWJsfgParmQZAPFnoBPHiLNoLY1ytF720UGozVD0tg6cAESP9hUrgA==
+  dependencies:
+    chokidar "2.1.2"
 
 nodemon@^1.19.4:
   version "1.19.4"
@@ -2617,6 +2653,18 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
+tail-file@1.4.13:
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/tail-file/-/tail-file-1.4.13.tgz#d2fc82077d79782ef69b7cbe4e80af6b5d961c27"
+  integrity sha512-jqpV21AInpN1mKVNAGAZF/QaM5kNgFzAsts5Mqry0bUsN+nO0QlM8qRByIQ5XQinAVCAbn9QKIK8ViaubB4WCA==
+  dependencies:
+    debug "^4.1.1"
+
+tail@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.3.tgz#37567adc4624a70b35f1d146c3376fa3d6ef7c04"
+  integrity sha512-s9NOGkLqqiDEtBttQZI7acLS8ycYK5sTlDwNjGnpXG9c8AWj0cfAtwEIzo/hVRMMiC5EYz+bXaJWC1u1u0GPpQ==
+
 tar-fs@^2.0.0, tar-fs@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
@@ -2788,9 +2836,10 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-upath@^1.1.1:
+upath@^1.1.0, upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 update-notifier@^2.5.0:
   version "2.5.0"
@@ -2922,6 +2971,13 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+ws@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.0.tgz#422eda8c02a4b5dba7744ba66eebbd84bcef0ec7"
+  integrity sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==
+  dependencies:
+    async-limiter "^1.0.0"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,7 +133,7 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
-async-limiter@^1.0.0:
+async-limiter@^1.0.0, async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
@@ -735,6 +735,13 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+express-ws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/express-ws/-/express-ws-4.0.0.tgz#dabd8dc974516418902a41fe6e30ed949b4d36c4"
+  integrity sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==
+  dependencies:
+    ws "^5.2.0"
 
 express@~4.16.1:
   version "4.16.4"
@@ -2971,6 +2978,13 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
This makes it so the app show page establishes a websocket connection with the server, which checks the app's health status every second and pushes the status to the client.

The heuristic for checking whether an app is healthy is whether it has more that 3 tasks that failed in the last minute. Because of this heuristic, it takes about 30 seconds for a new app that can't run to go from 'healthy' to 'unhealthy'.

It would be good to add an additional simple health check: we could just do a simple curl request to the app's URL and make sure we get back a non-error response.