### PR TITLE
add ability to set environment variables

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 var sassMiddleware = require('node-sass-middleware');
+var expressHandlebars = require('express-handlebars');
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -18,13 +19,19 @@ var app = express();
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');
+app.engine('.hbs', expressHandlebars({
+  extname: '.hbs',
+  layoutsDir: './views',
+  defaultLayout: 'layout',
+  helpers: require('./lib/HandlebarsHelpers')
+}));
 
 // logger setup
 app.use(logger('dev'));
 
 // parsing setup
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 // stylesheet setup

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -174,6 +174,8 @@ module.exports = {
   },
 
   updateEnvVar(req, res) {
+    // TODO: may be worth refactoring this later to be less brittle if request formatting is bad
+    // just return an error to client if request body was formatted incorrectly
     const submittedEnvVars = Object.keys(req.body).map(key => req.body[key]);
     const validEnvVars = submittedEnvVars.filter(env => env.key.trim().length && env.val.trim().length);
     const formattedEnvVars = validEnvVars.map(env => `${env.key.trim()}=${env.val.trim()}`)

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -169,4 +169,17 @@ module.exports = {
       .then(DockerWrapper.updateService(serviceConfig))
       .catch(error => console.log(error));
   },
+
+  updateEnvVar(req, res) {
+    let envVariables = Object.values(req.body).filter(envVar => envVar.indexOf('=') > -1);
+
+    App.findByPk(req.params.appId)
+      .then(app => app.update({ envVariables }))
+      .then(DockerWrapper.updateService())
+      .then((app) => {
+        res.redirect(`/apps/${req.params.appId}`);
+        return app;
+      })
+      .catch(error => console.log(error))
+  },
 };

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -171,10 +171,12 @@ module.exports = {
   },
 
   updateEnvVar(req, res) {
-    let envVariables = Object.values(req.body).filter(envVar => envVar.indexOf('=') > -1);
+    const submittedEnvVars = Object.keys(req.body).map(key => req.body[key]);
+    const validEnvVars = submittedEnvVars.filter(env => env.key.trim().length && env.val.trim().length);
+    const formattedEnvVars = validEnvVars.map(env => `${env.key.trim()}=${env.val.trim()}`)
 
     App.findByPk(req.params.appId)
-      .then(app => app.update({ envVariables }))
+      .then(app => app.update({ envVariables: formattedEnvVars }))
       .then(DockerWrapper.updateService())
       .then((app) => {
         res.redirect(`/apps/${req.params.appId}`);

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -302,7 +302,7 @@ module.exports = {
     });
   },
 
-  updateService: (updateConfig) => {
+  updateService: (updateConfig = {}) => {
     return (app) => {
       return new Promise(async (resolve, reject) => {
         app.emitEvent('Updating service...');

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -61,6 +61,24 @@ const getCurrentServiceConfig = (service) => {
   });
 };
 
+const generateServiceEnvVars = async (app) => {
+    const hasDatabase = await app.getDatabase();
+    let envVariables = [];
+
+    if (hasDatabase) {
+      envVariables = [`DATABASE_HOST=${app.title}_database`,
+                      "POSTGRES_USER=postgres",
+                      "POSTGRES_PASSWORD=password",
+                      `POSTGRES_DB=${app.title}`];
+    }
+
+    if (app.envVariables) {
+      envVariables = [...envVariables, ...app.envVariables];
+    }
+
+    return envVariables;
+};
+
 const buildDbDockerfile = (app) => {
   return new Promise((resolve, reject) => {
     fs.access(`./${app.path}/db/schema.sql`, fs.constants.F_OK, (err) => {
@@ -287,20 +305,24 @@ module.exports = {
   updateService: (updateConfig) => {
     return (app) => {
       return new Promise(async (resolve, reject) => {
-        console.log('Updating service...');
+        app.emitEvent('Updating service...');
         const managerNode = await getManagerNodeInstance();
         const service = managerNode.getService(`${app.title}_web`);
         const currentServiceConfig = await getCurrentServiceConfig(service);
 
         const currentServiceSpec = currentServiceConfig.Spec;
         const versionSpec = { _query: { "version": currentServiceConfig.Version.Index }};
-        const newConfig = Object.assign(currentServiceSpec, updateConfig, versionSpec);
+        const newConfig = Object.assign({}, currentServiceSpec, updateConfig, versionSpec);
+
+        newConfig.TaskTemplate.ContainerSpec.Env = await generateServiceEnvVars(app);
 
         service.update(newConfig, (error, result) => {
           if (error) {
             console.log(error);
             reject(error);
           }
+
+          app.emitEvent('Web service updated!');
           console.log('Web service updated!');
           resolve(app);
         });

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -62,7 +62,8 @@ const getCurrentServiceConfig = (service) => {
 };
 
 const generateServiceEnvVars = async (app) => {
-    const hasDatabase = await app.getDatabase();
+    const hasDatabase = app.databaseId !== null;
+
     let envVariables = [];
 
     if (hasDatabase) {

--- a/lib/HandlebarsHelpers.js
+++ b/lib/HandlebarsHelpers.js
@@ -1,0 +1,8 @@
+module.exports = {
+  envKey: function(str) {
+    return str.split('=')[0];
+  },
+  envVal: function(str) {
+    return str.split('=')[1];
+  },
+}

--- a/lib/HandlebarsHelpers.js
+++ b/lib/HandlebarsHelpers.js
@@ -5,4 +5,7 @@ module.exports = {
   envVal: function(str) {
     return str.split('=')[1];
   },
+  newEnvIndex: function(envVars) {
+    return envVars ? envVars.length : 0;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dockerode": "^3.0.2",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "express-handlebars": "^3.1.0",
     "hbs": "~4.0.4",
     "http-errors": "~1.6.3",
     "morgan": "~1.9.1",

--- a/public/stylesheets/style.sass
+++ b/public/stylesheets/style.sass
@@ -87,6 +87,17 @@ details[open] summary
   border-color: #f14668
   box-shadow: 0 0 0 1px #f14668
 
+.form-list-action-container
+  height: 2.5em
+  display: flex
+  align-items: center
+  justify-content: center
+
+// Utility
+.flex-float-right
+  margin-left: auto
+
+// Mobile
 @media only screen and (max-width: 600px)
   body
     display: block

--- a/routes/index.js
+++ b/routes/index.js
@@ -44,6 +44,8 @@ router.delete('/apps/:appId', appsController.destroy);
 // Database
 router.post('/apps/:appId/database', upload.single('file'), appsController.createDatabase);
 
+// Env Variables
+router.post('/apps/:appId/env', appsController.updateEnvVar);
 // Scale/Replicas
 router.post('/apps/:appId/scale', appsController.updateReplicas);
 
@@ -70,7 +72,7 @@ router.post('/apps/:appId/exec', (req, res) => {
         });
       });
 
-      const runOptions =  { 
+      const runOptions =  {
         Env: [
           // TODO: These shouldn't be hard-coded... store in db?
           `DATABASE_HOST=${app.title}_database`,

--- a/server/migrations/20191130215857-add-env-variables-to-apps.js
+++ b/server/migrations/20191130215857-add-env-variables-to-apps.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      'Apps',
+      'envVariables',
+      Sequelize.ARRAY(Sequelize.TEXT)
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'Apps',
+      'envVariables',
+      Sequelize.ARRAY(Sequelize.TEXT)
+    );
+  }
+};

--- a/server/models/app.js
+++ b/server/models/app.js
@@ -21,7 +21,11 @@ module.exports = (sequelize, DataTypes) => {
     filename: DataTypes.STRING,
     network: DataTypes.STRING,
     url: DataTypes.STRING,
-    envVariables: DataTypes.ARRAY(DataTypes.TEXT),
+    envVariables: {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
+      defaultValue: [],
+      allowNull: false,
+    },
     replicas: {
       type: DataTypes.INTEGER,
       defaultValue: 1,

--- a/server/models/app.js
+++ b/server/models/app.js
@@ -21,6 +21,7 @@ module.exports = (sequelize, DataTypes) => {
     filename: DataTypes.STRING,
     network: DataTypes.STRING,
     url: DataTypes.STRING,
+    envVariables: DataTypes.ARRAY(DataTypes.TEXT),
     replicas: {
       type: DataTypes.INTEGER,
       defaultValue: 1,

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -205,13 +205,14 @@
   (() => {
     // Update schema file upload field to reflect name of uploaded file
     const fileInput = document.querySelector('#file-js-example input[type=file]');
-    fileInput.onchange = () => {
-      if (fileInput.files.length > 0) {
-        const fileName = document.querySelector('#file-js-example .file-name');
-        fileName.textContent = fileInput.files[0].name;
+    if (fileInput) {
+      fileInput.onchange = () => {
+        if (fileInput.files.length > 0) {
+          const fileName = document.querySelector('#file-js-example .file-name');
+          fileName.textContent = fileInput.files[0].name;
+        }
       }
     }
-
     // Build terminal
     const terminalWrapper = document.getElementById('build-terminal');
     const terminal = document.querySelector('#build-terminal .terminal');

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -39,7 +39,12 @@
 <!-- App Database -->
 <div class="box">
   <details>
-    <summary>Database</summary>
+    <summary>
+      Database
+      {{#if app.database}}
+        <span class="tag is-rounded is-link is-light flex-float-right">Enabled</span>
+      {{/if}}
+    </summary>
 
     <div class="content">
       {{#if app.database}}

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -182,14 +182,14 @@
             <td>
               <div class="field">
                 <div class="control">
-                  <input class="input is-family-monospace" type="input" type="text" name="{{app.envVariables.length}}[key]" />
+                  <input class="input is-family-monospace" type="input" type="text" name="{{newEnvIndex app.envVariables}}[key]" />
                 </div>
               </div>
             </td>
             <td>
               <div class="field">
                 <div class="control">
-                  <input class="input is-family-monospace" type="input" type="text" name="{{app.envVariables.length}}[val]" />
+                  <input class="input is-family-monospace" type="input" type="text" name="{{newEnvIndex app.envVariables}}[val]" />
                 </div>
               </div>
             </td>

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -131,6 +131,54 @@
   </details>
 </div>
 
+<!-- Environment Variables -->
+<div class="box">
+  <details>
+    <summary>Custom Environment Variables</summary>
+
+    <div class="content">
+      <form method="POST" action="/apps/{{ app.id }}/env">
+        <table>
+          <tr>
+            <th>Key</th>
+            <th></th>
+          </tr>
+          {{#if app.envVariables.length}}
+            {{#each app.envVariables }}
+              <tr id="env-{{@index}}">
+                <td>
+                  <div class="field">
+                    <div class="control">
+                      <input class="input" type="text" value={{this}} name="env-{{@index}}" />
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <a class="delete env is-small" data-delete-id="#env-{{@index}}"></a>
+                </td>
+              </tr>
+            {{/each}}
+          {{/if}}
+          <tr>
+            <td>
+              <div class="field">
+                <div class="control">
+                  <input class="input" type="input" type="text" name="env-{{app.envVariables.length}}"
+                </div>
+              </div>
+            </td>
+          </tr>
+        </table>
+        <div class="field is-grouped">
+          <p class="control">
+            <input class="button is-link" type="submit" value="Save" />
+          </p>
+        </div>
+      </form>
+    </div>
+  </details>
+</div>
+
 <!-- Scaling -->
 <div class="box">
   <details>
@@ -252,5 +300,19 @@
       });
 
     });
+
+    // Env Variables
+
+    let removeEnvVariable = (evt) => {
+      evt.stopPropagation();
+      const elementId = evt.target.getAttribute('data-delete-id');
+      const element = document.querySelector(elementId);
+      element.parentNode.removeChild(element);
+    }
+
+    const deleteEnvButtons = document.querySelectorAll(".delete.env");
+    for (const button of deleteEnvButtons) {
+      button.addEventListener('click', removeEnvVariable);
+    }
   })();
 </script>

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -134,13 +134,18 @@
 <!-- Environment Variables -->
 <div class="box">
   <details>
-    <summary>Custom Environment Variables</summary>
+    <summary>Environment Variables
+      {{#if app.envVariables.length}}
+        <span class="tag is-rounded is-link is-light flex-float-right">{{ app.envVariables.length }}</span>
+      {{/if}}
+    </summary>
 
     <div class="content">
       <form method="POST" action="/apps/{{ app.id }}/env">
         <table>
           <tr>
             <th>Key</th>
+            <th>Value</th>
             <th></th>
           </tr>
           {{#if app.envVariables.length}}
@@ -149,12 +154,21 @@
                 <td>
                   <div class="field">
                     <div class="control">
-                      <input class="input" type="text" value={{this}} name="env-{{@index}}" />
+                      <input class="input is-family-monospace" type="text" value="{{envKey this}}" name="{{@index}}[key]" />
                     </div>
                   </div>
                 </td>
                 <td>
-                  <a class="delete env is-small" data-delete-id="#env-{{@index}}"></a>
+                  <div class="field">
+                    <div class="control">
+                      <input class="input is-family-monospace" type="text" value="{{envVal this}}" name="{{@index}}[val]" />
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="form-list-action-container">
+                    <a class="delete env" data-delete-id="#env-{{@index}}"></a>
+                  </div>
                 </td>
               </tr>
             {{/each}}
@@ -163,14 +177,25 @@
             <td>
               <div class="field">
                 <div class="control">
-                  <input class="input" type="input" type="text" name="env-{{app.envVariables.length}}"
+                  <input class="input is-family-monospace" type="input" type="text" name="{{app.envVariables.length}}[key]" />
                 </div>
               </div>
             </td>
+            <td>
+              <div class="field">
+                <div class="control">
+                  <input class="input is-family-monospace" type="input" type="text" name="{{app.envVariables.length}}[val]" />
+                </div>
+              </div>
+            </td>
+            <td></td>
           </tr>
         </table>
+
+        <hr/>
+
         <div class="field is-grouped">
-          <p class="control">
+          <p class="control flex-float-right">
             <input class="button is-link" type="submit" value="Save" />
           </p>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,11 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
+asap@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 asn1@~0.2.0, asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -330,6 +335,25 @@ chalk@^2.0.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chokidar@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
+  integrity sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.0"
+  optionalDependencies:
+    fsevents "^1.2.7"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -555,6 +579,13 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -711,6 +742,17 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+express-handlebars@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/express-handlebars/-/express-handlebars-3.1.0.tgz#c177ee9a81f6a2abada6b550b77b3e30c6bc0796"
+  integrity sha512-7QlaXnSREMmN5P2o4gmpUZDfJlLtfBka9d6r7/ccXaU7rPp76odw9YYtwZYdIiha2JqwiaG6o2Wu6NZJQ0u7Fg==
+  dependencies:
+    glob "^7.1.3"
+    graceful-fs "^4.1.2"
+    handlebars "^4.1.2"
+    object.assign "^4.1.0"
+    promise "^8.0.2"
 
 express@~4.16.1:
   version "4.16.4"
@@ -885,6 +927,11 @@ fstream@^1.0.0, fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -988,6 +1035,17 @@ handlebars@4.3.5:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.1.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -1008,6 +1066,11 @@ has-ansi@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
+  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1696,6 +1759,13 @@ node-sass@^4.3.0:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+nodejs-tail@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nodejs-tail/-/nodejs-tail-1.1.0.tgz#5e4316b079c4ec922e95ad8ac1f0a980ae7e0264"
+  integrity sha512-Gt2fi69P9tgdj41Xl9vFoLVcmnXW9uKQbWJsfgParmQZAPFnoBPHiLNoLY1ytF720UGozVD0tg6cAESP9hUrgA==
+  dependencies:
+    chokidar "2.1.2"
+
 nodemon@^1.19.4:
   version "1.19.4"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.4.tgz#56db5c607408e0fdf8920d2b444819af1aae0971"
@@ -1795,11 +1865,26 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@^1.0.11, object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -2017,6 +2102,13 @@ prepend-http@^1.0.1:
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+
+promise@^8.0.2:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.3.tgz#f592e099c6cddc000d538ee7283bb190452b0bf6"
+  integrity sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==
+  dependencies:
+    asap "~2.0.6"
 
 proxy-addr@~2.0.4:
   version "2.0.5"
@@ -2617,6 +2709,18 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
+tail-file@1.4.13:
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/tail-file/-/tail-file-1.4.13.tgz#d2fc82077d79782ef69b7cbe4e80af6b5d961c27"
+  integrity sha512-jqpV21AInpN1mKVNAGAZF/QaM5kNgFzAsts5Mqry0bUsN+nO0QlM8qRByIQ5XQinAVCAbn9QKIK8ViaubB4WCA==
+  dependencies:
+    debug "^4.1.1"
+
+tail@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.3.tgz#37567adc4624a70b35f1d146c3376fa3d6ef7c04"
+  integrity sha512-s9NOGkLqqiDEtBttQZI7acLS8ycYK5sTlDwNjGnpXG9c8AWj0cfAtwEIzo/hVRMMiC5EYz+bXaJWC1u1u0GPpQ==
+
 tar-fs@^2.0.0, tar-fs@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
@@ -2788,9 +2892,10 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
-upath@^1.1.1:
+upath@^1.1.0, upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
 update-notifier@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
This adds the ability to set/delete environment variables for an app from the app show page.

This PR does a few things under the hood to support this (if you wonder about something I mention, search the variable name in the list of changes and you'll see it)

- Adds an `envVariables` column to the app model, it's an array of text elements
- In order to have a richer editing experience I needed to enable server-side Handlebars helpers by adding the express library and enabling it (this allows me to break an environment variable up into two fields on the front end, one for the key and one for the value)
- I also needed to enable the `extended` prop for the `.urlencoded` setting in Express since that allowed me to nest form objects during submission (check out the `name` props on the fields on the front end to see what I mean).
- The last notable change is in relation to the `DockerWrapper.updateService` method. The method now sets the appropriate environment variables for the service. It does this by determining whether the service has a database AND whether the service has any custom environment variables. It compiles the necessary environment variables and sets them during the service update.