### PR TITLE
Update apps (without a database)

### DIFF
--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -78,16 +78,16 @@ module.exports = {
     await moveApplicationFile(req);
 
     App
-       .findByPk(req.params.appId)
-       .then((app) => app.update({ filename: app.filename }))
-       .then((app) => {
-          return new Promise(async(resolve, reject) => {
+      .findByPk(req.params.appId)
+      .then((app) => app.update({ filename: app.filename }))
+      .then((app) => {
+        return new Promise(async(resolve, reject) => {
           
           app.emitEvent(`Updating application '${app.title}'`);
           res.redirect(`/apps/${app.id}?events`);
           resolve(app);
         });
-       })
+      })
       .then(DockerWrapper.buildDockerfile(req.file.filename + '.zip'))
       .then(DockerWrapper.buildImage)
       .then(DockerWrapper.updateService)

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -63,6 +63,10 @@ module.exports = {
       .catch(error => { console.log(error); });
   },
 
+  update(req, res) {
+    console.log('updating application', req.file.filename);
+  },
+
   list(req, res) {
     return App.findAll()
       .then(apps => {
@@ -91,6 +95,23 @@ module.exports = {
       })
       .catch(error => res.status(400).send(error));
   },
+
+  showUpdatePage(req, res) {
+    return App
+      .findByPk(req.params.appId, {
+        include: [{model: Database, as: 'database'}]
+      })
+      .then(app => {
+        if (!app) {
+          return res.status(404).send({
+            message: 'App Not Found'
+          });
+        }
+
+        res.render('apps/update', { app });
+      })
+      .catch(error => res.status(400).send(error));
+  },    
 
   destroy(req, res) {
     return App

--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -63,8 +63,38 @@ module.exports = {
       .catch(error => { console.log(error); });
   },
 
-  update(req, res) {
-    console.log('updating application', req.file.filename);
+  async update(req, res) {
+    if (!req.file || req.file.mimetype !== 'application/zip') {
+      return res.render('apps/update', { errors: [{ message: 'Please attach a .zip file of your application.' }] })
+    }
+
+    const app = {
+      title: req.body.title,
+      path: `uploads/${req.body.title}`,
+      filename: req.file.filename + '.zip',
+      network: `${req.body.title}_default`
+    };
+
+    await moveApplicationFile(req);
+
+    App
+       .findByPk(req.params.appId)
+       .then((app) => app.update({ filename: app.filename }))
+       .then((app) => {
+          return new Promise(async(resolve, reject) => {
+          
+          app.emitEvent(`Updating application '${app.title}'`);
+          res.redirect(`/apps/${app.id}?events`);
+          resolve(app);
+        });
+       })
+      .then(DockerWrapper.buildDockerfile(req.file.filename + '.zip'))
+      .then(DockerWrapper.buildImage)
+      .then(DockerWrapper.updateService)
+      .then((app) => {
+        app.emitEvent('===END===');
+      })
+      .catch(error => { console.log(error); });
   },
 
   list(req, res) {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -284,27 +284,48 @@ module.exports = {
     });
   },
 
-  updateService: (updateConfig) => {
-    return (app) => {
-      return new Promise(async (resolve, reject) => {
-        console.log('Updating service...');
-        const managerNode = await getManagerNodeInstance();
-        const service = managerNode.getService(`${app.title}_web`);
-        const currentServiceConfig = await getCurrentServiceConfig(service);
+  updateService: (app) => {
+    return new Promise(async (resolve, reject) => {
+      const managerNode = await getManagerNodeInstance();
+      const proxyConfig = await Config.findOne({
+        where: { key: 'proxyNetwork' }
+      });
+      
+      const serviceParams = {
+        "Name": `${app.title}_web`,
+        "Labels": {
+          "com.df.notify": "true",
+          "com.df.serviceDomain": app.url,
+          "com.df.port": "4567" // TODO: This shouldn't be hard-coded
+        },
+        "TaskTemplate": {
+          "ContainerSpec": {
+            "Image": `${app.title}:latest`,
+          },
+          "Networks": [
+            { "Target": `${app.network}` },
+            { "Target": proxyConfig.value }
+          ]
+        },
+      };
 
-        const currentServiceSpec = currentServiceConfig.Spec;
-        const versionSpec = { _query: { "version": currentServiceConfig.Version.Index }};
-        const newConfig = Object.assign(currentServiceSpec, updateConfig, versionSpec);
+      console.log(serviceParams);
 
-        service.update(newConfig, (error, result) => {
-          if (error) {
-            console.log(error);
-            reject(error);
-          }
-          console.log('Web service updated!');
+      const service = managerNode.getService(`${app.title}_web`);
+
+      service.inspect((error, result) => {
+        const version = result.Version.Index;
+        serviceParams._query = { "version": version };
+        console.log(serviceParams);
+        console.log('updating web service');
+        app.emitEvent('Updating web service');
+
+        service.update(serviceParams, (error, result) => {
+          if (error) { console.log(error); }
+          app.emitEvent('Web service updated!');
           resolve(app);
         });
       });
-    };
+    });
   },
 };

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -309,15 +309,11 @@ module.exports = {
         },
       };
 
-      console.log(serviceParams);
-
       const service = managerNode.getService(`${app.title}_web`);
 
       service.inspect((error, result) => {
         const version = result.Version.Index;
         serviceParams._query = { "version": version };
-        console.log(serviceParams);
-        console.log('updating web service');
         app.emitEvent('Updating web service');
 
         service.update(serviceParams, (error, result) => {

--- a/routes/index.js
+++ b/routes/index.js
@@ -40,6 +40,7 @@ router.get('/apps/new', appsController.new);
 router.get('/apps/:appId', appsController.show);
 router.get('/apps/update/:appId', appsController.showUpdatePage);
 router.post('/apps', upload.single('file'), appsController.create);
+router.post('/apps/update/:appId', upload.single('file'), appsController.update);
 router.delete('/apps/:appId', appsController.destroy);
 
 // Database

--- a/routes/index.js
+++ b/routes/index.js
@@ -38,6 +38,7 @@ router.get('/events/:appId/exec', eventLogger.appExecEvents);
 router.get('/apps', appsController.list);
 router.get('/apps/new', appsController.new);
 router.get('/apps/:appId', appsController.show);
+router.get('/apps/update/:appId', appsController.showUpdatePage);
 router.post('/apps', upload.single('file'), appsController.create);
 router.delete('/apps/:appId', appsController.destroy);
 

--- a/views/apps/index.hbs
+++ b/views/apps/index.hbs
@@ -28,7 +28,7 @@
                   </td>
                   <td>
                     <div class="buttons are-small is-pulled-right">
-                      <a href="/apps/edit/{{ id }}" class="button is-light">Edit</a>
+                      <a href="/apps/update/{{ id }}" class="button is-light">Update</a>
                       <a class="button is-danger is-light">Delete (NYI)</a>
                     </div>
                   </td>

--- a/views/apps/update.hbs
+++ b/views/apps/update.hbs
@@ -23,6 +23,16 @@
       {{/if}}
 
       <form method="POST" action="/apps/update/{{app.id}}" enctype="multipart/form-data">
+
+        <div class="field" hidden>
+          <label class="label">Name</label>
+
+          <div class="control">
+            <input class="input" type="text" name="title" value="{{ app.title }}" placeholder="my-new-app" />
+          </div>
+        </div>
+
+
         <div class="field">
           <label class="label">Application File</label>
           <div id="file-js-example" class="file has-name">

--- a/views/apps/update.hbs
+++ b/views/apps/update.hbs
@@ -1,0 +1,69 @@
+<div class="columns">
+  <div class="column is-half">
+
+    <div class="box">
+      <h1 class="subtitle">Update App</h1>
+
+      {{#if errors}}
+        <article class="message is-danger">
+          <div class="message-body">
+            <ul>
+              {{#each errors}}
+                <li>{{this.message}}</li>
+              {{/each}}
+            </ul>
+          </div>
+        </article>
+      {{else}}
+        <article class="message is-info">
+          <div class="message-body">
+            To update your application, attach a .zip file containing your app's source code and click update. We'll take care of the rest.
+          </div>
+        </article>
+      {{/if}}
+
+      <form method="POST" action="/apps/update/{{app.id}}" enctype="multipart/form-data">
+        <div class="field">
+          <label class="label">Application File</label>
+          <div id="file-js-example" class="file has-name">
+            <label class="file-label">
+              <input class="file-input" type="file" name="file">
+              <span class="file-cta">
+                <span class="file-icon">
+                  <i class="fas fa-upload"></i>
+                </span>
+                <span class="file-label">
+                  Choose a file…
+                </span>
+              </span>
+              <span class="file-name">
+                No file uploaded
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <hr/>
+
+        <div class="field is-grouped">
+          <p class="control">
+            <button type="submit" class="button is-link">Update</button>
+          </p>
+          <p class="control">
+            <a class="button" href="/apps">Cancel</a>
+          </p>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  const fileInput = document.querySelector('#file-js-example input[type=file]');
+  fileInput.onchange = () => {
+   if (fileInput.files.length > 0) {
+     const fileName = document.querySelector('#file-js-example .file-name');
+     fileName.textContent = fileInput.files[0].name;
+   }
+  }
+</script>


### PR DESCRIPTION
Updating services using the Dockerode API, steps involved:

 - Query Apps model for app with corresponding ID
 - Generate service params for updating
 - Query manager for relevant node and get version
 - Send update request for service instance