### PR TITLE
Cascade delete of database on app deletion

### DIFF
--- a/controllers/apps.js
+++ b/controllers/apps.js
@@ -38,11 +38,7 @@ const destroyAppWithDatabase = (app) => {
       .then(DockerWrapper.pruneDatabaseVolume)
       .then(DockerWrapper.destroyNetwork)
       .then((app) => {
-        const appId = app.id
-        App.destroy({  where: { id: appId } })
-          .then(() => {
-            Database.destroy({  where: { app_id: app.id } })
-          });
+        App.destroy({  where: { id: app.id } });
       });
   });
 }

--- a/server/migrations/20191206193703-remove-database-fkey-constraint.js
+++ b/server/migrations/20191206193703-remove-database-fkey-constraint.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeConstraint(
+      'Databases', 
+      'Databases_app_id_fkey'
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint(
+      'Databases',
+      ['app_id'],
+      {   
+        type: 'foreign key',
+        name: 'Databases_app_id_fkey',
+        references: { model: { tableName: 'Apps' }, key: 'id' },
+      }
+    );
+  },
+};

--- a/server/migrations/20191206194622-change-database-to-add-cascade-delete-fkey.js
+++ b/server/migrations/20191206194622-change-database-to-add-cascade-delete-fkey.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('Databases', 'app_id', {
+      type: Sequelize.INTEGER,
+      references: { model: { tableName: 'Apps' }, key: 'id' },
+      allowNull: false,
+      onDelete: 'CASCADE',
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('Databases', 'app_id', {
+      type: Sequelize.INTEGER,
+      references: { model: { tableName: 'Apps' }, key: 'id' },
+      allowNull: false,
+    });
+  },
+}


### PR DESCRIPTION
- Adds an on-delete cascade to the foreign key of the Databases table
- Updates deletion logic for apps with database, since cascade will take care of deletion from Databases table

Fixes #57 