### PR TITLE
Fixes bug where the field of only the SQL file was updating

### DIFF
--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -406,16 +406,29 @@
 
   // Handling build output
   (() => {
-    // Update schema file upload field to reflect name of uploaded file
-    const fileInput = document.querySelector('#file-js-example input[type=file]');
-    if (fileInput) {
-      fileInput.onchange = () => {
-        if (fileInput.files.length > 0) {
-          const fileName = document.querySelector('#file-js-example .file-name');
-          fileName.textContent = fileInput.files[0].name;
+
+   // Update zip file upload field to reflect name of uploaded file
+    const fileInputZip = document.querySelector('#file-js-zip input[type=file]');
+    if (fileInputZip) {
+      fileInputZip.onchange = () => {
+        if (fileInputZip.files.length > 0) {
+          const fileNameZip = document.querySelector('#file-js-zip .file-name');
+          fileNameZip.textContent = fileInputZip.files[0].name;
         }
       }
     }
+
+    // Update schema file upload field to reflect name of uploaded file
+    const fileInputSQL = document.querySelector('#file-js-sql input[type=file]');
+    if (fileInputSQL) {
+      fileInputSQL.onchange = () => {
+        if (fileInputSQL.files.length > 0) {
+          const fileNameSQL = document.querySelector('#file-js-sql .file-name');
+          fileNameSQL.textContent = fileInputSQL.files[0].name;
+        }
+      }
+    }
+
     // Build terminal
     const terminalWrapper = document.getElementById('build-terminal');
     const terminal = document.querySelector('#build-terminal .terminal');

--- a/views/apps/show.hbs
+++ b/views/apps/show.hbs
@@ -71,7 +71,7 @@
         <p>
           <form method="POST" action="/apps/{{app.id}}/deploy" enctype="multipart/form-data">
             <div class="field">
-              <div class="file-js file is-small has-name">
+              <div id="file-js-zip" class="file is-small has-name">
                 <label class="file-label">
                   <input class="file-input" type="file" name="file">
 
@@ -139,7 +139,7 @@
 
         <form method="POST" action="/apps/{{app.id}}/database" enctype="multipart/form-data">
           <div class="field">
-            <div id="file-js-example" class="file is-small has-name">
+            <div id="file-js-sql" class="file is-small has-name">
               <label class="file-label">
                 <input class="file-input" type="file" name="file">
 


### PR DESCRIPTION
Gave the relevant divs two IDs instead of one class, because they're separate elements.
Preserves most of the logic of the function instead of having to use `querySelectorAll`.