### PR TITLE
cluster-scaling-feature

### DIFF
--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -23,4 +23,43 @@ module.exports = {
         }
       });
   },
-}
+
+  async create(req, res) {
+    const nodes = await Node.findAll();
+    const workerNodes = nodes.filter(node => node.manager === false);
+    const managerNode = nodes.find(node => node.manager === true);
+    const allNodesActive = nodes.every(node => node.active);
+
+    if (!allNodesActive) {
+      const errors = [{ message: 'Node cannot be added while cluster is updating.' }];
+      return res.render('cluster/index', { errors, nodes });
+    }
+
+    const DO_TOKEN = ''; // TODO: send from API
+
+    const name = `worker-${uuid()}`;
+    const nodeParams = {
+      name,
+      manager: false,
+      active: false
+    };
+
+    console.log('Creating node in db...');
+    Node.create(nodeParams)
+    .then(() => res.redirect('/cluster'))
+    .then(DockerWrapper.createMachine(name, DO_TOKEN))
+    .then(DockerWrapper.joinSwarm(name))
+    .then(async () => {
+      const workerNode = await Node.findOne({ where: { name }});
+      const workerIp   = await DockerWrapper.getNodeIp(name).catch(errHandler);
+      console.log(`Updating db with IP address of worker node (${workerIp})...`);
+      const params = {
+        ip_address: workerIp,
+        active: true,
+      };
+      return workerNode.update(params);
+    })
+    .catch(errHandler);
+  },
+
+};

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -15,7 +15,8 @@ module.exports = {
         } else {
           res.json({ nodes });
         }
-      }).catch(error => {
+      })
+      .catch(error => {
         if (req.accepts('html')) {
           res.status(400).send(error);
         } else {
@@ -29,11 +30,11 @@ module.exports = {
     const workerNodes = nodes.filter(node => node.manager === false);
     const managerNode = nodes.find(node => node.manager === true);
     const allNodesActive = nodes.every(node => node.active);
-		const accessToken = req.body.accessToken;
+    const accessToken = req.body.accessToken;
 
     if (!allNodesActive) {
       const errors = [{ message: 'Node cannot be added while cluster is updating.' }];
-			return res.status(400).send({ errors });
+      return res.status(400).send({ errors });
     }
 
     const name = `worker-${uuid()}`;
@@ -45,27 +46,27 @@ module.exports = {
 
     console.log('Creating node in db...');
     Node.create(nodeParams)
-    	.then(() => {
-				return res.status(202).send({ message: "Cluster scale started. (This process may take a few moments)" });
-			})
-    	.then(DockerWrapper.createMachine(name, accessToken)) // TODO: This is a user input value. Sanitization?
-			.catch(async (err) => {
-				const workerNode = await Node.findOne({ where: { name }});
-				await workerNode.destroy().catch(errHandler);
-				throw err;
-			})
-	    .then(DockerWrapper.joinSwarm(name))
-	    .then(async () => {
-	      const workerNode = await Node.findOne({ where: { name }});
-	      const workerIp   = await DockerWrapper.getNodeIp(name).catch(errHandler);
-	      console.log(`Updating db with IP address of worker node (${workerIp})...`);
-	      const params = {
-	        ip_address: workerIp,
-	        active: true,
-	      };
-	      return workerNode.update(params);
-	    })
-	    .catch(errHandler);
+      .then(() => {
+        return res.status(202).send({ message: "Cluster scale started. (This process may take a few moments)" });
+      })
+      .then(DockerWrapper.createMachine(name, accessToken)) // TODO: This is a user input value. Sanitization?
+      .catch(async (err) => {
+        const workerNode = await Node.findOne({ where: { name }});
+        await workerNode.destroy().catch(errHandler);
+        throw err;
+      })
+      .then(DockerWrapper.joinSwarm(name))
+      .then(async () => {
+        const workerNode = await Node.findOne({ where: { name }});
+        const workerIp   = await DockerWrapper.getNodeIp(name).catch(errHandler);
+        console.log(`Updating db with IP address of worker node (${workerIp})...`);
+        const params = {
+          ip_address: workerIp,
+          active: true,
+        };
+        return workerNode.update(params);
+      })
+      .catch(errHandler);
   },
 
 
@@ -77,22 +78,22 @@ module.exports = {
 
     if (!allNodesActive) {
       const errors = [{ message: 'Node cannot be removed while cluster is updating.' }];
-			return res.status(400).send({ errors });
+      return res.status(400).send({ errors });
     }
 
     if (workerNodes.length === 0) {
       const errors = [{ message: 'There are no nodes to remove!' }];
-			return res.status(400).send({ errors });
+      return res.status(400).send({ errors });
     }
 
     const workerNode = workerNodes[0];
 
-		workerNode.update({ active: false })
-			.then(() => {
-				return res.status(202).send({ message: "Cluster scale started. (This process may take a few moments)" });
-			})
-			.then(DockerWrapper.workerLeaveSwarm(workerNode.name))
-			.then(DockerWrapper.removeMachine(workerNode.name))    // -- https://github.com/vweevers/node-docker-machine/issues/30
-			.then(() => workerNode.destroy())
+    workerNode.update({ active: false })
+      .then(() => {
+        return res.status(202).send({ message: "Cluster scale started. (This process may take a few moments)" });
+      })
+      .then(DockerWrapper.workerLeaveSwarm(workerNode.name))
+      .then(DockerWrapper.removeMachine(workerNode.name))    // -- https://github.com/vweevers/node-docker-machine/issues/30
+      .then(() => workerNode.destroy())
   }
 };

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -48,6 +48,11 @@ module.exports = {
     Node.create(nodeParams)
     .then(() => res.redirect('/cluster'))
     .then(DockerWrapper.createMachine(name, DO_TOKEN))
+		.catch(async (err) => {
+			const workerNode = await Node.findOne({ where: { name }});
+			await workerNode.destroy().catch(errHandler);
+			throw err;
+		})
     .then(DockerWrapper.joinSwarm(name))
     .then(async () => {
       const workerNode = await Node.findOne({ where: { name }});
@@ -81,7 +86,7 @@ module.exports = {
 
     const workerNode = workerNodes[0];
 
-    workerNode.update({ active: false })
+		workerNode.update({ active: false })
 			.then(DockerWrapper.workerLeaveSwarm(workerNode.name))
 			.then(DockerWrapper.removeMachine(workerNode.name))    // -- https://github.com/vweevers/node-docker-machine/issues/30
 			.then(() => workerNode.destroy())

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -95,5 +95,6 @@ module.exports = {
       .then(DockerWrapper.workerLeaveSwarm(workerNode.name))
       .then(DockerWrapper.removeMachine(workerNode.name))    // -- https://github.com/vweevers/node-docker-machine/issues/30
       .then(() => workerNode.destroy())
+      .catch(errHandler);
   }
 };

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -1,3 +1,11 @@
+const DockerWrapper = require('../lib/DockerWrapper');
+const Node = require('../server/models').Node;
+const Database = require('../server/models').Database;
+const Config = require('../server/models').Config;
+const Machine = require('docker-machine');
+const uuid = require('uuid/v4');
+const errHandler = e => console.log(e);
+
 module.exports = {
 	show(req, res) {
     res.render('cluster');

--- a/controllers/cluster.js
+++ b/controllers/cluster.js
@@ -7,7 +7,20 @@ const uuid = require('uuid/v4');
 const errHandler = e => console.log(e);
 
 module.exports = {
-	show(req, res) {
-    res.render('cluster');
+  list(req, res) {
+    return Node.findAll()
+      .then(nodes => {
+        if (req.accepts('html')) {
+          res.render('cluster/index', { nodes });
+        } else {
+          res.json({ nodes });
+        }
+      }).catch(error => {
+        if (req.accepts('html')) {
+          res.status(400).send(error);
+        } else {
+          res.status(400).json({ error });
+        }
+      });
   },
 }

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -138,6 +138,21 @@ const buildDbDockerfile = (app) => {
   });
 };
 
+const createMachine = (name, accessToken) => {
+  return () => {
+    return new Promise((resolve, reject) => {
+      const options = { 'digitalocean-access-token': accessToken };
+
+      console.log(`Creating docker machine '${name}'...`);
+      Machine.create(name, 'digitalocean', options, (err, result) => {
+        console.log('result', result);
+        if (err) { reject(err); }
+        resolve();
+      });
+    });
+  };
+};
+
 module.exports = {
   getNodeInstance: async (name) => {
     return await getNodeInstance(name)
@@ -149,6 +164,10 @@ module.exports = {
 
   getNodeIp: (name) => {
     return getNodeIp(name);
+  },
+
+  createMachine: (name, accessToken) => {
+    return createMachine(name, accessToken);
   },
 
   buildDockerfile: (filename) => {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -158,7 +158,6 @@ const createMachine = (name, accessToken) => {
 
       console.log(`Creating docker machine '${name}'...`);
       Machine.create(name, 'digitalocean', options, (err, result) => {
-        console.log('result', result);
         if (err) { reject(err); }
         resolve();
       });

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -98,6 +98,18 @@ const getManagerNodeInstance = () => {
   });
 };
 
+const getManagerNodeIp = () => {
+  return new Promise(async (resolve, reject) => {
+    const manager = await Node.findOne({ where: { manager: true }});
+
+    if (manager.ip_address) {
+      resolve(manager.ip_address);
+    } else {
+      reject();
+    }
+  });
+};
+
 const getCurrentServiceConfig = (service) => {
   return new Promise((resolve, reject) => {
     service.inspect((error, result) => {
@@ -197,6 +209,10 @@ module.exports = {
 
   getManagerNodeInstance: async () => {
     return await getManagerNodeInstance()
+  },
+
+  getManagerNodeIp: () => {
+    return getManagerNodeIp();
   },
 
   getNodeIp: (name) => {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -30,6 +30,46 @@ const DB_DOCKERFILE_CONTENT = `FROM postgres`;
 const DB_DOCKERFILE_WITH_SCHEMA_CONTENT = `FROM postgres
 COPY Dockerfile schema.* /docker-entrypoint-initdb.d/`;
 
+const getNodeInstance = (name) => {
+  return new Promise((resolve, reject) => {
+    Node.findOne({ where: { name }}).then((node) => {
+      const machine = new Machine(node.name);
+
+      machine.env({ parse: true }, (err, result) => {
+        if (err) { console.log(err); }
+        const certPath = result.DOCKER_CERT_PATH;
+        const hostWithPort = result.DOCKER_HOST.split('//')[1];
+        const host = hostWithPort.split(':')[0];
+        const port = hostWithPort.split(':')[1];
+
+        const options = {
+          socketPath: undefined,
+          host: host,
+          port: Number(port),
+          ca: fs.readFileSync(certPath + '/ca.pem'),
+          cert: fs.readFileSync(certPath + '/cert.pem'),
+          key: fs.readFileSync(certPath + '/key.pem'),
+        };
+
+        const docker = new Docker(options);
+        resolve(docker);
+      });
+    });
+  });
+};
+
+const getNodeIp = (name) => {
+  return new Promise(async(resolve, reject) => {
+    const node = await Node.findOne({ where: { name }});
+    const machine = new Machine(node.name);
+
+    machine.inspect((err, result) => {
+      if (err) { reject(err); }
+      resolve(result.driver.ipAddress);
+    });
+  })
+};
+
 const getManagerNodeInstance = () => {
   return new Promise((resolve, reject) => {
     Node.findOne({ where: { manager: true }}).then((manager) => {
@@ -99,8 +139,16 @@ const buildDbDockerfile = (app) => {
 };
 
 module.exports = {
-  getManagerNodeInstance: async() => {
+  getNodeInstance: async (name) => {
+    return await getNodeInstance(name)
+  },
+
+  getManagerNodeInstance: async () => {
     return await getManagerNodeInstance()
+  },
+
+  getNodeIp: (name) => {
+    return getNodeIp(name);
   },
 
   buildDockerfile: (filename) => {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -103,10 +103,10 @@ const getManagerNodeIp = () => {
   return new Promise(async (resolve, reject) => {
     const manager = await Node.findOne({ where: { manager: true }});
 
-    if (manager.ip_address) {
+    if (manager && manager.ip_address) {
       resolve(manager.ip_address);
     } else {
-      reject();
+      reject('Node IP Address not found!');
     }
   });
 };

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -153,6 +153,43 @@ const createMachine = (name, accessToken) => {
   };
 };
 
+const getWorkerJoinToken = () => {
+  return new Promise(async (resolve, reject) => {
+    const dockerManagerNode = await getManagerNodeInstance();
+
+    dockerManagerNode.swarmInspect((err, result) => {
+      if (err) { reject(err); }
+      resolve(result.JoinTokens.Worker);
+    });
+  });
+};
+
+const joinSwarm = (name) => {
+  return () => {
+    return new Promise(async (resolve, reject) => {
+      console.log('Getting worker node...');
+      const workerIp = await getNodeIp(name).catch(errHandler);
+      const managerIp = await getManagerNodeIp().catch(errHandler);
+      const workerNode = await getNodeInstance(name).catch(errHandler);
+
+      console.log('Getting join token...');
+      const joinToken = await getWorkerJoinToken().catch(err => console.log(err));
+      const options = {
+        'ListenAddr': '0.0.0.0:2377',           // This is the default in the docker API (dockerode seems to pass '' if not specified)
+        'AdvertiseAddr': workerIp,              // IP address of the worker node
+        'RemoteAddrs': [`${managerIp}:2377`],   // IP Address of manager node
+        'JoinToken': joinToken,
+      };
+
+      console.log('Attempting to join swarm...');
+      workerNode.swarmJoin(options, (err, result) => {
+        if (err) { reject(err); }
+        resolve(name);
+      });
+    });
+  }
+};
+
 module.exports = {
   getNodeInstance: async (name) => {
     return await getNodeInstance(name)
@@ -168,6 +205,10 @@ module.exports = {
 
   createMachine: (name, accessToken) => {
     return createMachine(name, accessToken);
+  },
+
+  joinSwarm: (name) => {
+    return joinSwarm(name);
   },
 
   buildDockerfile: (filename) => {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -166,6 +166,17 @@ const createMachine = (name, accessToken) => {
   };
 };
 
+const removeMachine = (name) => {
+  return () => {
+    return new Promise((resolve, reject) => {
+      Machine.command(['rm', name, '-y'], (err, result) => {
+        if (err) { reject(err); }
+        resolve(result);
+      });
+    });
+  };
+};
+
 const getWorkerJoinToken = () => {
   return new Promise(async (resolve, reject) => {
     const dockerManagerNode = await getManagerNodeInstance();
@@ -222,6 +233,10 @@ module.exports = {
 
   createMachine: (name, accessToken) => {
     return createMachine(name, accessToken);
+  },
+
+  removeMachine: (name) => {
+    return removeMachine(name);
   },
 
   joinSwarm: (name) => {

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -8,6 +8,7 @@ const uuidv1 = require('uuid/v1')
 const slugify = require('slugify');
 const tar = require('tar-fs');
 const moment = require('moment');
+const errHandler = e => console.log(e);
 
 const webDockerfileContent = (filename) => {
   return `FROM gliderlabs/herokuish as builder

--- a/lib/DockerWrapper.js
+++ b/lib/DockerWrapper.js
@@ -214,6 +214,18 @@ const joinSwarm = (name) => {
   }
 };
 
+const workerLeaveSwarm = (name) => {
+  return () => {
+    return new Promise(async (resolve, reject) => {
+      const worker = await getNodeInstance(name);
+      worker.swarmLeave({}, (err, result) => {
+        if (err) { reject(err); }
+        resolve(result);
+      });
+    });
+  };
+};
+
 module.exports = {
   getNodeInstance: async (name) => {
     return await getNodeInstance(name)
@@ -241,6 +253,10 @@ module.exports = {
 
   joinSwarm: (name) => {
     return joinSwarm(name);
+  },
+
+  workerLeaveSwarm: (name) => {
+    return workerLeaveSwarm(name);
   },
 
   buildDockerfile: (filename) => {

--- a/routes/index.js
+++ b/routes/index.js
@@ -52,7 +52,9 @@ router.post('/apps/:appId/env', appsController.updateEnvVar);
 router.post('/apps/:appId/scale', appsController.updateReplicas);
 
 //Cluster
-router.get('/cluster', clusterController.show);
+router.get('/cluster', clusterController.list);
+router.post('/cluster/create', clusterController.create);
+router.post('/cluster/delete', clusterController.delete);
 
 // API
 router.get('/api/apps', appsController.list);

--- a/routes/index.js
+++ b/routes/index.js
@@ -54,8 +54,6 @@ router.post('/apps/:appId/dbdestroy', appsController.destroyDB);
 
 //Cluster
 router.get('/cluster', clusterController.list);
-router.post('/cluster/create', clusterController.create);
-router.post('/cluster/delete', clusterController.delete);
 
 // API
 router.get('/api/apps', appsController.list);
@@ -64,5 +62,8 @@ router.post('/api/apps/:appId/deploy', middlewares.upload().single('file'), apps
 router.get('/api/events/:appId', eventLogger.appEvents);
 router.get('/api/apps/:appId/dbdump', appsController.dbDump);
 router.post('/api/apps/:appId/dbdestroy', appsController.destroyDB);
+
+router.post('/api/cluster/create', clusterController.create);
+router.post('/api/cluster/delete', clusterController.delete);
 
 module.exports = router;

--- a/routes/middlewares.js
+++ b/routes/middlewares.js
@@ -63,6 +63,8 @@ module.exports = {
       res.locals.activePage = { users: true };
     } else if (path.startsWith('/apps')) {
       res.locals.activePage = { apps: true };
+    } else if (path.startsWith('/cluster')) {
+      res.locals.activePage = { cluster: true };
     }
 
     next();

--- a/server/migrations/20191213145251-add-active-to-nodes.js
+++ b/server/migrations/20191213145251-add-active-to-nodes.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      'Nodes',
+      'active',
+      Sequelize.BOOLEAN
+    );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'Nodes',
+      'active',
+      Sequelize.BOOLEAN
+    );
+  }
+};

--- a/server/models/node.js
+++ b/server/models/node.js
@@ -4,7 +4,12 @@ module.exports = (sequelize, DataTypes) => {
   const Node = sequelize.define('Node', {
     name: DataTypes.STRING,
     manager: DataTypes.BOOLEAN,
-    ip_address: DataTypes.STRING
+    ip_address: DataTypes.STRING,
+    active: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
   }, {});
 
   Node.associate = function(models) {

--- a/views/cluster/index.hbs
+++ b/views/cluster/index.hbs
@@ -2,14 +2,6 @@
   <div class="column">
       <h1 class="subtitle">
         {{nodes.length}} nodes
-
-        <form method="POST" action="/cluster/create">
-          <input type="submit" value="Add Node" class="button is-link is-pulled-right"/>
-        </form>
-
-        <form method="POST" action="/cluster/delete">
-          <input type="submit" value="Remove Node" class="button is-link is-pulled-right"/>
-        </form>
       </h1>
 
       {{#if errors}}

--- a/views/cluster/index.hbs
+++ b/views/cluster/index.hbs
@@ -24,15 +24,23 @@
               <tr>
                 <td>Name</td>
                 <td>IP Address</td>
+                <td>Active</td>
               </tr>
               </thead>
               {{#each nodes}}
                 <tr>
                   <td>
-                    <a href="/nodes/{{ id }}">{{name}}</a>
+                    {{name}}
                   </td>
                   <td>
                     {{ ip_address }}
+                  </td>
+                  <td>
+                    {{#if active}}
+                    Yes
+                    {{else}}
+                    No
+                    {{/if}}
                   </td>
                 </tr>
               {{/each}}

--- a/views/cluster/index.hbs
+++ b/views/cluster/index.hbs
@@ -1,0 +1,53 @@
+<div class="columns">
+  <div class="column">
+      <h1 class="subtitle">
+        {{nodes.length}} nodes
+
+        <form method="POST" action="/cluster/create">
+          <input type="submit" value="Add Node" class="button is-link is-pulled-right"/>
+        </form>
+
+        <form method="POST" action="/cluster/delete">
+          <input type="submit" value="Remove Node" class="button is-link is-pulled-right"/>
+        </form>
+      </h1>
+
+      {{#if errors}}
+        <article class="message is-danger">
+          <div class="message-body">
+            <ul>
+              {{#each errors}}
+                <li>{{this.message}}</li>
+              {{/each}}
+            </ul>
+          </div>
+        </article>
+      {{/if}}
+
+      {{#if nodes.length}}
+        <div class="box">
+          <div class="table-container">
+            <table class="table is-hoverable is-fullwidth">
+              <thead>
+              <tr>
+                <td>Name</td>
+                <td>IP Address</td>
+              </tr>
+              </thead>
+              {{#each nodes}}
+                <tr>
+                  <td>
+                    <a href="/nodes/{{ id }}">{{name}}</a>
+                  </td>
+                  <td>
+                    {{ ip_address }}
+                  </td>
+                </tr>
+              {{/each}}
+            </table>
+          </div>
+        </div>
+      {{/if}}
+
+  </div>
+</div>

--- a/views/layout-internal.hbs
+++ b/views/layout-internal.hbs
@@ -39,12 +39,25 @@
 
     <section class="section main-section">
       <div class="breadcrumb">
+        {{#if activePage.apps}}
         <ul>
           <li><a href="/apps">Apps</a></li>
           {{#if app}}
             <li class="is-active"><a href="#" aria-current="page">{{app.title}}</a></li>
           {{/if}}
         </ul>
+        {{else if activePage.users}}
+        <ul>
+          <li><a href="/users">Users</a></li>
+          {{#if user}}
+            <li class="is-active"><a href="#" aria-current="page">{{user.firstName}} {{user.lastName}}</a></li>
+          {{/if}}
+        </ul>
+        {{else if activePage.cluster}}
+        <ul>
+          <li><a href="/cluster">Cluster</a></li>
+        </ul>
+        {{/if}}
       </div>
       <div class="container">
           <div class="columns">

--- a/views/layout-internal.hbs
+++ b/views/layout-internal.hbs
@@ -15,17 +15,15 @@
 
     <nav class="main-nav">
       <a href="/apps" class="logo text-tight is-size-4 has-text-centered has-text-weight-xbold">Mothership</a>
-
         <ul>
-
           <li class="{{#if activePage.apps}}is-active{{/if}}" style="">
             <a href="/apps">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-box"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
               <span>Apps</span>
             </a>
-          </li><li class="">
+          </li><li class="{{#if activePage.cluster}}is-active{{/if}}">
             <a href="/cluster">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-sliders"><line x1="4" y1="21" x2="4" y2="14"></line><line x1="4" y1="10" x2="4" y2="3"></line><line x1="12" y1="21" x2="12" y2="12"></line><line x1="12" y1="8" x2="12" y2="3"></line><line x1="20" y1="21" x2="20" y2="16"></line><line x1="20" y1="12" x2="20" y2="3"></line><line x1="1" y1="14" x2="7" y2="14"></line><line x1="9" y1="8" x2="15" y2="8"></line><line x1="17" y1="16" x2="23" y2="16"></line></svg>
+              <i class="fa fa-server"></i>
               <span>Cluster</span>
             </a>
           </li>
@@ -37,7 +35,6 @@
           </li>
           {{/if}}
         </ul>
-
     </nav>
 
     <section class="section main-section">


### PR DESCRIPTION
## This PR...
- Adds API endpoints for scaling the Swarm cluster up and down
- Makes the breadcrumbs feature at the top of pages a little more useful
- Adds an index page under `/cluster` that shows the nodes in the cluster (this is just a placeholder until we get our final designs)

---

## Some notes on cluster scaling
- These endpoints assume they are being used by the CLI (JSON responses), we're planning to start with only scaling the cluster from the CLI.
- This PR adds an `active` column to the `Nodes` table.
- When a request comes in to add a node to the cluster...
  - A new row is added to the `Nodes` table, with an `active` value of `false`.
  - A request is made to create a new Docker Machine
    - If the docker-machine create is successful...
      - The new machine is joined to the swarm
      - The row in the `Nodes` table is updated with the IP Address of the node, and `active` is set to `true`
    - If the docker-machine create is unsuccessful...
      - The row in the `Nodes` table is removed, since we weren't able to create/add the node to the swarm (in the future when we have a more robust messaging system we may want to alert the user more directly)
- When a request comes in to remove a node from the cluster...
  - We determine how many workers are in the cluster.
    - If the cluster includes one or more workers...
      - We choose one worker to remove.
      - We set the `active` flag on this node to `false`
      - We issue a command on the node to leave the swarm
      - We issue a command to remove the docker-machine
      - We delete the node from the `Nodes` table
    - If the cluster has no workers...
      - We return a message telling the user there are no nodes to remove.
 - Note the interaction these actions have with manipulating the `active` flag on the `Nodes` table. We use this flag in both endpoints. If a request is fielded to scale the cluster up or down and **any** row in the nodes table has an `active` value of `false`, we return early and tell the user the cluster is currently undergoing changes and they need to wait for it to finish before requesting another change.
  - Technically, there are some edge cases where a node could get into a weird state with the way this system works. I've tried to catch the common edge cases I know of, and rather than implementing some cron job that checks whether the system is in a weird state and tries to fix it, I'm scheming a followup command the user could run that would clean up any dangling nodes. I'm trying to balance the creeping scope of this feature against our desire to get a basic starting place for the ability to scale the cluster.

---

## Notes on nodes leaving a swarm in Docker Swarm Mode

There are two steps for a node to _completely_ leave a swarm in DSM. Note, I'll speak first on the CLI commands and then to the underlying Docker API requests at work.

A worker leaving the swarm in DSM is seemingly easy. Documentation says to issue the following CLI command _from the worker_ to be removed:

```sh
$ docker swarm leave
```

However, documentation also specifies that if we were to check the nodes in the swarm _after_ issuing this command...

> The node will still appear in the node list, and marked as `down`. It no longer affects swarm operation, but a long list of `down` nodes can clutter the node list. To remove an inactive node from the list, use the `node rm` command.

So here we see that the node will still appear if we check the nodes in the a swarm, but "marked" as `down`. This seems to imply that the node has left the swarm, but some amount of metadata is left behind. As such, we can move to a node in the swarm and issue the `node rm NODE_ID` command to full remove the dangling metadata about the former node.

Fully 'leaving' or removing a node from the swarm then requires making at least **2** API requests to Docker:

1) [Leaving the swarm](https://docs.docker.com/engine/api/v1.30/#operation/SwarmLeave)
2) ['Deleting' the old node](https://docs.docker.com/engine/api/v1.30/#operation/NodeDelete)

(More info on this [here](https://github.com/docker/swarmkit/issues/2369))

So I tried doing exactly that. I first issued the API request to leave the swarm from the perspective of the node, then, I subsequently issued a request on the swarm manager to delete the remaining node information.

As it turns out, in order for a node deletion request to be successful, the node the request is issued for must be considered 'down' by the swarm. It seems as though when a node 'leaves' the swarm, it doesn't necessarily send a message to the swarm that it's leaving (or, if it does, it does so asynchronously). Instead, it appears to just up and leave, and the swarm becomes aware that the node is "down" after an unspecified period of time **based on a heartbeat** (or rather, the absence of one).

Coincidently, this introduces a race condition when interacting with Docker programmatically. The initial request for the node to leave comes back, and a followup request is issued for the swarm to "remove" whatever remains (seemingly metadata) about the node. The second request actually fails, and says that the node can't be removed because it isn't down.

I confirmed that this is a race condition in testing by wrapping the second request in a very small timeout of a second or two (I generally found this to be long enough for DSM to become aware of the node being down), and the second request was successful.


### Options:

#### 1. Set a timeout on the second command

We could use some code like I did during testing, wrapping the followup command in a small timeout. Unfortunately, this isn't a good solution because it's impossible to know what the right amount of time would be. We don't know what might make detecting the down state happen faster or slower than normal, or what the bounds of that timeframe would be.

#### 2. Ignore the issue

From what I understand, only metadata about the node remains on the swarm if the node isn't formally removed from the perspective of the node. (Users of Mothership won't even run `docker node ls` so this is probably ok)

#### 3. Force the second command

- The `docker node rm` command and API request offer a `force` option.
- Forcing the removal of a node from the swarm _can_ cause interruptions, but in this case, in theory, the worker has already 'left' the swarm, the swarm just doesn't know it yet.
- I'm guessing this has at least a non-zero chance of causing a momentary hiccup, though, because DSM probably offloads tasks from one node to another once it detects a node is down (which it hasn't yet)

Faced with these options, I chose option 2 for now. The swarm seems only to retain metadata if the second request isn't made. We can test once we've added a visualizer whether dangling nodes show up, and if so we can force the delete. However, at this point, I felt the non-zero chance of service interruption wasn't worth  removing old metadata for `docker node ls` commands.