### PR TITLE
Allow authenticating WebSocket requests over API

### DIFF
--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -107,13 +107,15 @@ wsTerminal.on('connection', async function connection(ws, request) {
 // we made it through, otherwise it will return a 302 redirecting to /login,
 // which means the request was not authenticated.
 const authenticateRequest = async(request) => {
+  const authPath = request.url.startsWith('/api') ? '/api/wsauth' : '/wsauth';
+
   const headersWithoutUpgrade = Object.keys(request.headers)
     .filter(key => key !== 'upgrade' && key !== 'connection')
     .reduce((headers, key) => {
       return { ...headers, [key]: request.headers[key] };
     }, {})
 
-  const response = await fetch('http://localhost:3000/wsauth', {
+  const response = await fetch('http://localhost:3000' + authPath, {
     headers: headersWithoutUpgrade,
     redirect: 'manual'
   });

--- a/routes/index.js
+++ b/routes/index.js
@@ -70,4 +70,8 @@ router.post('/api/apps/:appId/dbdestroy', appsController.destroyDB);
 router.post('/api/cluster/create', clusterController.create);
 router.post('/api/cluster/delete', clusterController.delete);
 
+router.get('/api/wsauth', (req, res) => {
+  res.status(200).send('ok');
+});
+
 module.exports = router;


### PR DESCRIPTION
Establishing a WebSocket connection through the API requires
sending a JSON token, thus we need to pass these upgrade requests
to an /api/wsauth route so that our JWT authenticator will be used
instead of the normal session authenticator.