### PR TITLE
Add HTTPS support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 .git
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY . /usr/src/app/
 
 RUN yarn install
 
-EXPOSE 443 80
+EXPOSE 443 80 3000
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY . /usr/src/app/
 
 RUN yarn install
 
-EXPOSE 443
+EXPOSE 443 80
 
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY . /usr/src/app/
 
 RUN yarn install
 
-EXPOSE 3000
+EXPOSE 443
 
 CMD ["yarn", "start"]

--- a/bin/www
+++ b/bin/www
@@ -33,6 +33,14 @@ const server = https.createServer({
 }, app);
 server.listen(port, () => console.log(`HTTPS server listening: https://localhost`));
 
+// redirect HTTP server
+const httpApp = express();
+httpApp.all('*', (req, res) => {
+  console.log('res.redirect')
+  res.redirect('https://localhost')
+});
+const httpServer = http.createServer(httpApp);
+httpServer.listen(80, () => console.log(`HTTP server listening: http://localhost`));
 
 /**
  * Handle websocket upgrades, pass to appropriate WebSocket Server

--- a/bin/www
+++ b/bin/www
@@ -11,36 +11,41 @@ const https = require('https');
 const fs = require('fs');
 const upgradeToWebSocket = require('../lib/WebSocket');
 const express = require('express');
+let server;
+let httpServer;
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-// const server = https.createServer(app);
+if (process.env.SSL) { // If SSL enabled
+  // Create HTTPS server
+  server = https.createServer({
+    key: fs.readFileSync(process.env.SSL_KEY_PATH),
+    cert: fs.readFileSync(process.env.SSL_CERT_PATH),
+    ca: fs.readFileSync(process.env.SSL_CA_PATH),
+  }, app);
+  server.listen(port, () => console.log(`HTTPS server listening: https://localhost`));
 
-// HTTPS server
-const server = https.createServer({
-  key: fs.readFileSync(process.env.SSL_KEY_PATH),
-  cert: fs.readFileSync(process.env.SSL_CERT_PATH),
-  ca: fs.readFileSync(process.env.SSL_CA_PATH),
-}, app);
-server.listen(port, () => console.log(`HTTPS server listening: https://localhost`));
-
-// redirect HTTP server
-const httpApp = express();
-httpApp.all('*', (req, res) => {
-  console.log('res.redirect')
-  res.redirect('https://localhost')
-});
-const httpServer = http.createServer(httpApp);
-httpServer.listen(80, () => console.log(`HTTP server listening: http://localhost`));
+  // Create HTTP server for redirects
+  const httpApp = express();
+  httpApp.all('*', (req, res) => {
+    console.log('http request, res.redirect')
+    res.redirect('https://localhost' + ':' + port)
+  });
+  httpServer = http.createServer(httpApp);
+  httpServer.listen(80, () => console.log(`HTTP server listening: http://localhost`));
+} else { // If SSL NOT enabled
+  server = http.createServer(app);
+  server.listen(port);
+}
 
 /**
  * Handle websocket upgrades, pass to appropriate WebSocket Server

--- a/bin/www
+++ b/bin/www
@@ -23,7 +23,16 @@ app.set('port', port);
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+// const server = https.createServer(app);
+
+// HTTPS server
+const server = https.createServer({
+  key: fs.readFileSync(process.env.SSL_KEY_PATH),
+  cert: fs.readFileSync(process.env.SSL_CERT_PATH),
+  ca: fs.readFileSync(process.env.SSL_CA_PATH),
+}, app);
+server.listen(port, () => console.log(`HTTPS server listening: https://localhost`));
+
 
 /**
  * Handle websocket upgrades, pass to appropriate WebSocket Server
@@ -35,7 +44,6 @@ server.on('upgrade', upgradeToWebSocket);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/bin/www
+++ b/bin/www
@@ -38,7 +38,7 @@ if (process.env.SSL) { // If SSL enabled
   const httpApp = express();
   httpApp.all('*', (req, res) => {
     console.log('http request, res.redirect')
-    res.redirect('https://localhost' + ':' + port)
+    res.redirect(`https://${req.hostname}:${port}`)
   });
   httpServer = http.createServer(httpApp);
   httpServer.listen(80, () => console.log(`HTTP server listening: http://localhost`));

--- a/bin/www
+++ b/bin/www
@@ -4,10 +4,13 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('paas:server');
-var http = require('http');
-var upgradeToWebSocket = require('../lib/WebSocket');
+const app = require('../app');
+const debug = require('debug')('paas:server');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const upgradeToWebSocket = require('../lib/WebSocket');
+const express = require('express');
 
 /**
  * Get port from environment and store in Express.

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -139,7 +139,7 @@ Create a `docker-compose.yml` file on the Mothership server with the following c
 ```yml
 services:
   web:
-    image: jkulton/paas:latest
+    image: mothershippaas/mothership:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /root/.docker:/root/.docker

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -48,11 +48,20 @@ docker-machine create --driver digitalocean --digitalocean-access-token YOUR_DO_
 ## 5. Set up Docker Swarm
 
 ```
+docker-machine ip mothership-swarm
+```
+
+Take note of this IP address.
+
+```
 eval $(docker-machine env mothership-swarm)
 ```
+
 ```
-docker swarm init --advertise-addr 68.183.149.75
+docker swarm init --advertise-addr YOUR_MOTHERSHIP_SWARM_IP
 ```
+(`YOUR_MOTHERSHIP_SWARM_IP` should be the IP address from the `docker-machine ip` command)
+
 ```
 docker network create --driver overlay proxy
 ```
@@ -94,7 +103,6 @@ docker-machine ip mothership-swarm
 ```
 (Note the result of this command)
 
-
 You'll now need to add a couple of resource records to your DNS provider:
 
 | Name | Type | Value |
@@ -107,7 +115,7 @@ You'll now need to add a couple of resource records to your DNS provider:
 
 ## 7. SSL
 
-Install [Certbot](https://certbot.eff.org/instructions) (If you used `docker-machine` to create the server, use the instructions for Ubuntu)
+Install [Certbot](https://certbot.eff.org/instructions) (If you used `docker-machine` to create the server, use the [instructions for Ubuntu](https://certbot.eff.org/lets-encrypt/ubuntuxenial-other))
 
 For this walkthrough, we'll use Certbot in standalone mode.
 
@@ -132,11 +140,13 @@ The paths for these files will be needed when starting Mothership for the first 
 Create a `docker-compose.yml` file on the Mothership server with the following content.
 
 * For `MOTHERSHIP_DOMAIN` fill in your domain **without** any subdomains (`example.com`).
-* For `MOTHERSHIP_MANAGER_IP` fill in the IP address of the Mothership Swarm Manager from **Step 6**.
+* For `MOTHERSHIP_MANAGER_IP` fill in the IP address of the Mothership Swarm Manager (`docker-machine ip mothership-swarm`).
 * For `SSL_KEY_PATH`, `SSL_CERT_PATH`, and `SSL_CA_PATH` add the paths for the files from **Step 7**.
   * (It's likely you only need to replace the `YOUR_DOMAIN` bit if you used Certbot)
 
 ```yml
+version: '3'
+
 services:
   web:
     image: mothershippaas/mothership:latest

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -1,0 +1,208 @@
+# Manual Setup
+
+## Prerequisites
+
+* [Docker](https://docker.com/)
+* [docker-machine](https://docs.docker.com/v17.09/machine/install-machine/)
+* DigitalOcean account (or other IaaS)
+* Domain for use with Mothership
+
+---
+
+## 1. Create a server for Mothership using docker-machine
+
+```
+docker-machine create --driver digitalocean --digitalocean-access-token YOUR_DO_ACCESS_TOKEN mothership-paas
+```
+
+_(command may differ for another IaaS provider, refer to docker-machine docs for more info)_
+
+## 2. SSH into 'mothership-paas'
+
+```
+docker-machine ssh mothership-paas
+```
+
+## 3. Install docker-compose and docker-machine
+
+```
+sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+```
+base=https://github.com/docker/machine/releases/download/v0.16.2 &&
+curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/tmp/docker-machine &&
+sudo mv /tmp/docker-machine /usr/local/bin/docker-machine &&
+chmod +x /usr/local/bin/docker-machine
+```
+
+## 4. Create server for Mothership Swarm Manager
+
+**While still SSHed into the Mothership Server** issue the following command
+
+```
+docker-machine create --driver digitalocean --digitalocean-access-token YOUR_DO_ACCESS_TOKEN mothership-swarm
+```
+
+## 5. Set up Docker Swarm
+
+```
+eval $(docker-machine env mothership-swarm)
+```
+```
+docker swarm init --advertise-addr 68.183.149.75
+```
+```
+docker network create --driver overlay proxy
+```
+```
+docker service create --name swarm-listener \
+--network proxy \
+--mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock" \
+-e DF_NOTIFY_CREATE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/reconfigure \
+-e DF_NOTIFY_REMOVE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/remove \
+--constraint 'node.role==manager' \
+dockerflow/docker-flow-swarm-listener
+```
+```
+docker service create --name proxy \
+-p 80:80 \
+-p 443:443 \
+--network proxy \
+-e LISTENER_ADDRESS=swarm-listener \
+dockerflow/docker-flow-proxy
+```
+```
+eval $(docker-machine env -u)
+```
+
+## 6. DNS Setup
+
+Get the IP address of the **Mothership server**
+
+```
+dig +short myip.opendns.com @resolver1.opendns.com
+```
+
+(Node the result of this command)
+
+Get the IP address of the **Mothership swarm manager**
+
+```
+docker-machine ip mothership-swarm
+```
+(Note the result of this command)
+
+
+You'll now need to add a couple of resource records to your DNS provider:
+
+| Name | Type | Value |
+|------|------|-------|
+| @ | A | _Mothership swarm manager ip_ |
+| * | A | _Mothership swarm manager ip_ |
+| mothership | A | _Mothership server ip_ |
+
+(Don't move forward in the tutorial until you've done this.)
+
+## 7. SSL
+
+Install [Certbot](https://certbot.eff.org/instructions) (If you used `docker-machine` to create the server, use the instructions for Ubuntu)
+
+For this walkthrough, we'll use Certbot in standalone mode.
+
+**When asked what domain you'd like to get the cert for answer in the format `mothership.YOUR_DOMAIN`**. (e.g. if you'd like to deploy Mothership on `example.com` you'd answer with `mothership.example.com`)
+
+```
+sudo certbot certonly --standalone
+```
+
+Follow the prompts for the command. Once Certbot finishes, take note of the location of the cert, key, and chain. They should look something like this:
+
+```
+/etc/letsencrypt/live/mothership.YOUR_DOMAIN/privkey.pem
+/etc/letsencrypt/live/mothership.YOUR_DOMAIN/cert.pem
+/etc/letsencrypt/live/mothership.YOUR_DOMAIN/chain.pem
+```
+
+The paths for these files will be needed when starting Mothership for the first time.
+
+## 8. Create Docker Compose file
+
+Create a `docker-compose.yml` file on the Mothership server with the following content.
+
+* For `MOTHERSHIP_DOMAIN` fill in your domain **without** any subdomains (`example.com`).
+* For `MOTHERSHIP_MANAGER_IP` fill in the IP address of the Mothership Swarm Manager from **Step 6**.
+* For `SSL_KEY_PATH`, `SSL_CERT_PATH`, and `SSL_CA_PATH` add the paths for the files from **Step 7**.
+  * (It's likely you only need to replace the `YOUR_DOMAIN` bit if you used Certbot)
+
+```yml
+services:
+  web:
+    image: jkulton/paas:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /root/.docker:/root/.docker
+      - /etc/letsencrypt:/etc/letsencrypt
+    environment:
+      - NODE_ENV=production
+      - SESSION_SECRET=foobarbaz
+      - REDIS_HOST=redis
+      - DB_USERNAME=postgres
+      - DB_NAME=paas_development
+      - DB_HOST=database
+      - DB_PASSWORD=password
+      - MOTHERSHIP_DOMAIN=
+      - MOTHERSHIP_MANAGER_NAME=mothership-swarm
+      - MOTHERSHIP_MANAGER_IP=
+      - PORT=443
+      - SSL=true
+      - SSL_KEY_PATH=/etc/letsencrypt/live/mothership.YOUR_DOMAIN/privkey.pem
+      - SSL_CERT_PATH=/etc/letsencrypt/live/mothership.YOUR_DOMAIN/cert.pem
+      - SSL_CA_PATH=/etc/letsencrypt/live/mothership.YOUR_DOMAIN/chain.pem
+    ports:
+      - "443:443"
+      - "80:80"
+
+  database:
+    image: postgres
+    environment:
+      - POSTGRES_DB=paas_development
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis
+
+volumes:
+  db_data:
+```
+
+## 9. Start Mothership server
+
+After creating and fill the `docker-compose.yml` file with your appropriate values, start the server:
+
+```
+docker-compose up -d
+```
+
+Next, migrate and seed the database:
+
+```
+docker-compose run web ./node_modules/.bin/sequelize db:migrate
+docker-compose run web ./node_modules/.bin/sequelize db:seed:all
+```
+
+## 10. Change Admin password
+
+* Your Mothership should now be live and ready to use!
+* You should log in to your Mothership and change the default admin username/password:
+
+```
+username: admin@mothership.live
+password: m0th3rsh1p
+```
+
+* **Be sure to log in and change the username + password!**
+* **Do NOT lose access to this account!**

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -163,7 +163,7 @@ const authenticateRequest = async(request) => {
       'Bearer ' + request.headers['sec-websocket-protocol'];
   }
 
-  const response = await fetch('http://localhost:3000' + authPath, {
+  const response = await fetch('https://localhost' + authPath, { // TODO: set dynamically using env var
     headers: headersWithoutUpgrade,
     redirect: 'manual'
   });

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -145,6 +145,9 @@ wsTerminal.on('connection', async function connection(ws, request) {
 // which means the request was not authenticated.
 const authenticateRequest = async(request) => {
   const authPath = request.url.startsWith('/api') ? '/api/wsauth' : '/wsauth';
+  const authProtocol = process.env.SSL ? 'https:' : 'http:';
+  const appPort = process.env.PORT || '3000';
+  const authUrl = `${authProtocol}//localhost:${appPort}${authPath}`;
 
   const headersWithoutUpgrade = Object.keys(request.headers)
     .filter(key => key !== 'upgrade' && key !== 'connection')
@@ -163,7 +166,7 @@ const authenticateRequest = async(request) => {
       'Bearer ' + request.headers['sec-websocket-protocol'];
   }
 
-  const response = await fetch('https://localhost' + authPath, { // TODO: set dynamically using env var
+  const response = await fetch(authUrl, {
     headers: headersWithoutUpgrade,
     redirect: 'manual'
   });

--- a/public/javascripts/app-show-controller.js
+++ b/public/javascripts/app-show-controller.js
@@ -78,6 +78,7 @@ class AppShowController {
 
       term = new Terminal({
         cursorBlink: true,
+        fontFamily: 'Fira Code',
         theme: {
           black: '#252525',
           red: '#FF443E',
@@ -89,7 +90,6 @@ class AppShowController {
           white: '#F5F5F5',
           foreground: '#A1B0B8',
           background: '#151515',
-          fontFamily: 'Fira Code',
         }
       });
 
@@ -158,6 +158,7 @@ class AppShowController {
     if (showTerminal) {
       buildTerminal = new Terminal({
         convertEol: true,
+        fontFamily: 'Fira Code',
         theme: {
           black: '#252525',
           red: '#FF443E',
@@ -169,7 +170,6 @@ class AppShowController {
           white: '#F5F5F5',
           foreground: '#A1B0B8',
           background: '#151515',
-          fontFamily: 'Fira Code',
         }
       });
       const appEventEndpoint = new EventSource(`/events/${this.app.id}`);
@@ -276,6 +276,7 @@ class AppShowController {
       websocket.onopen = () => {
         logTerminal = new Terminal({
           convertEol: true,
+          fontFamily: 'Fira Code',
           theme: {
             black: '#252525',
             red: '#FF443E',
@@ -287,7 +288,6 @@ class AppShowController {
             white: '#F5F5F5',
             foreground: '#A1B0B8',
             background: '#151515',
-            fontFamily: 'Fira Code',
           }
         });
 

--- a/public/javascripts/app-show-controller.js
+++ b/public/javascripts/app-show-controller.js
@@ -14,7 +14,7 @@ class AppShowController {
       return;
     }
 
-    const healthUrl = `ws://${window.location.host}/app-health?appId=${this.app.id}`;
+    const healthUrl = `wss://${window.location.host}/app-health?appId=${this.app.id}`;
     const websocket = new WebSocket(healthUrl);
 
     websocket.onopen = () => console.log('Connected to app-health');
@@ -71,7 +71,7 @@ class AppShowController {
       terminalModal.classList.add('is-active');
 
       websocket = new WebSocket(
-        `ws://localhost:3000/terminal?appTitle=${this.app.title}&command=bash`
+        `wss://${window.location.host}/terminal?appTitle=${this.app.title}&command=bash`
       );
 
       term = new Terminal({
@@ -268,7 +268,7 @@ class AppShowController {
       logModal.classList.add('is-active');
 
       websocket = new WebSocket(
-        `ws://${window.location.host}/app-logs?appId=${this.app.id}`
+        `wss://${window.location.host}/app-logs?appId=${this.app.id}`
       );
 
       websocket.onopen = () => {

--- a/public/javascripts/app-show-controller.js
+++ b/public/javascripts/app-show-controller.js
@@ -5,6 +5,8 @@ class AppShowController {
       title: title,
       deployed: deployed
     };
+    this.sslEnabled = (window.location && window.location.protocol === 'https:');
+    this.websocketProtocol = this.sslEnabled ? 'wss:' : 'ws:';
   };
 
   enableAppHealth() {
@@ -14,7 +16,7 @@ class AppShowController {
       return;
     }
 
-    const healthUrl = `wss://${window.location.host}/app-health?appId=${this.app.id}`;
+    const healthUrl = `${this.websocketProtocol}//${window.location.host}/app-health?appId=${this.app.id}`;
     const websocket = new WebSocket(healthUrl);
 
     websocket.onopen = () => console.log('Connected to app-health');
@@ -71,7 +73,7 @@ class AppShowController {
       terminalModal.classList.add('is-active');
 
       websocket = new WebSocket(
-        `wss://${window.location.host}/terminal?appTitle=${this.app.title}&command=bash`
+        `${this.websocketProtocol}//${window.location.host}/terminal?appTitle=${this.app.title}&command=bash`
       );
 
       term = new Terminal({
@@ -268,7 +270,7 @@ class AppShowController {
       logModal.classList.add('is-active');
 
       websocket = new WebSocket(
-        `wss://${window.location.host}/app-logs?appId=${this.app.id}`
+        `${this.websocketProtocol}//${window.location.host}/app-logs?appId=${this.app.id}`
       );
 
       websocket.onopen = () => {

--- a/public/javascripts/app-show-controller.js
+++ b/public/javascripts/app-show-controller.js
@@ -78,7 +78,6 @@ class AppShowController {
 
       term = new Terminal({
         cursorBlink: true,
-        fontFamily: 'Fira Code',
         theme: {
           black: '#252525',
           red: '#FF443E',
@@ -90,6 +89,7 @@ class AppShowController {
           white: '#F5F5F5',
           foreground: '#A1B0B8',
           background: '#151515',
+          fontFamily: 'Fira Code',
         }
       });
 
@@ -158,7 +158,6 @@ class AppShowController {
     if (showTerminal) {
       buildTerminal = new Terminal({
         convertEol: true,
-        fontFamily: 'Fira Code',
         theme: {
           black: '#252525',
           red: '#FF443E',
@@ -170,6 +169,7 @@ class AppShowController {
           white: '#F5F5F5',
           foreground: '#A1B0B8',
           background: '#151515',
+          fontFamily: 'Fira Code',
         }
       });
       const appEventEndpoint = new EventSource(`/events/${this.app.id}`);
@@ -276,7 +276,6 @@ class AppShowController {
       websocket.onopen = () => {
         logTerminal = new Terminal({
           convertEol: true,
-          fontFamily: 'Fira Code',
           theme: {
             black: '#252525',
             red: '#FF443E',
@@ -288,6 +287,7 @@ class AppShowController {
             white: '#F5F5F5',
             foreground: '#A1B0B8',
             background: '#151515',
+            fontFamily: 'Fira Code',
           }
         });
 

--- a/views/layout-internal.hbs
+++ b/views/layout-internal.hbs
@@ -7,6 +7,7 @@
     <style>
       @import url('https://fonts.googleapis.com/css?family=Squada+One&display=swap');
     </style>
+    <link href="https://fonts.googleapis.com/css?family=Fira+Code:300,400,500,600,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/stylesheets/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/xterm/3.14.5/xterm.css">
   </head>


### PR DESCRIPTION
* Adds support to Mothership for HTTPS (note this is for Mothership itself, not for deployed apps)
  * This is enabled via a few environment variables:
    * `PORT=443` (`443` is suggested if enabling SSL
    * `SSL=true`
    * `SSL_KEY_PATH`, `SSL_CERT_PATH`, `SSL_CA_PATH` (these should be the paths to the respective files for the cert)
* Basically, if SSL is enabled Mothership will start two servers: an HTTP server and an HTTPS server. Requests to HTTP URLs will be forwarded to HTTPS. If SSL **isn't** enabled, Mothership will only start an HTTP server. (See [this bit](https://github.com/unnamed-paas/paas/pull/87/files#diff-731ce67b643e6620e04781e9683be0d9R28-R48) for details)
* Adds manual deployment documentation (check out `./docs/manual-deploy.md`)